### PR TITLE
Fix issue with missing arguments for centroid_batch function when using asso_func='centroid'

### DIFF
--- a/boxmot/trackers/deepocsort/deep_ocsort.py
+++ b/boxmot/trackers/deepocsort/deep_ocsort.py
@@ -463,7 +463,11 @@ class DeepOCSort(BaseTracker):
             left_trks = last_boxes[unmatched_trks]
             left_trks_embs = trk_embs[unmatched_trks]
 
-            iou_left = self.asso_func(left_dets, left_trks)
+            
+            iou_left = self.asso_func(
+                *(left_dets, left_trks, self.width, self.height) if self.asso_func.__name__ == 'centroid_batch'
+                else (left_dets, left_trks)
+            )
             # TODO: is better without this
             emb_cost_left = left_dets_embs @ left_trks_embs.T
             if self.embedding_off:

--- a/boxmot/trackers/ocsort/ocsort.py
+++ b/boxmot/trackers/ocsort/ocsort.py
@@ -298,7 +298,7 @@ class OCSort(BaseTracker):
         if self.use_byte and len(dets_second) > 0 and unmatched_trks.shape[0] > 0:
             u_trks = trks[unmatched_trks]
             iou_left = self.asso_func(
-                dets_second, u_trks
+                *(dets_second, u_trks, w, h) if self.asso_func.__name__ == 'centroid_batch' else (dets_second, u_trks)
             )  # iou between low score detections and unmatched tracks
             iou_left = np.array(iou_left)
             if iou_left.max() > self.asso_threshold:


### PR DESCRIPTION
The centroid_batch function requires additional w and h arguments, unlike other IOU functions. However, in the current method, even when using the centroid method, only bboxes1 and bboxes2 are passed, resulting in an error.

#1372 
Error message: `TypeError: centroid_batch() missing 2 required positional arguments: 'w' and 'h'`

To resolve this issue, I have modified the method to correctly pass the w and h arguments to the centroid_batch function when the centroid method is used.

Changes made:

Added w and h arguments when calling the centroid_batch function.
This fix will resolve the error when using the centroid method.

Thank you.

