### PR TITLE
Fix: Mistake in handling the output features of ReID model in TensorRT

### DIFF
--- a/boxmot/appearance/backends/tensorrt_backend.py
+++ b/boxmot/appearance/backends/tensorrt_backend.py
@@ -116,7 +116,7 @@ class TensorRTBackend(BaseModelBackend):
             # Execute inference
             self.context.execute_v2(list(self.binding_addrs.values()))
             features = self.bindings["output"].data
-            resultant_features.append(features)
+            resultant_features.append(features.clone())
 
         if len(resultant_features)== 1:
             return resultant_features[0]


### PR DESCRIPTION
Sorry for the oversight in my previous submission. In the previous submission, I was adding reference of "features" variable to resultant array which is obviously not the correct approach. I have fixed the issue by first cloning the "features" variable .