### PR TITLE
FIX: RuntimeError: expected scalar type Float but found Half error on…

### DIFF
--- a/boxmot/appearance/backbones/clip/clip/model.py
+++ b/boxmot/appearance/backbones/clip/clip/model.py
@@ -157,8 +157,11 @@ class LayerNorm(nn.LayerNorm):
 
     def forward(self, x: torch.Tensor):
         orig_type = x.dtype
-        ret = super().forward(x.type(torch.float32))
-        return ret.type(orig_type)
+        for param in self.parameters():
+            if param.dtype == torch.float16:
+                param.data = param.data.to(torch.float32)
+        ret = super().forward(x.to(torch.float32))
+        return ret.to(orig_type)
 
 
 class QuickGELU(nn.Module):


### PR DESCRIPTION
For the CLIP model, if I run the following command 
python track.py --source=coffeshop_short.mp4 --yolo-model=yolov8n.engine --reid-model=clip_market1501.pt --half
 I get this errror 
File "/usr/local/lib/python3.8/dist-packages/torch/nn/functional.py", line 2486, in layer_norm
    return torch.layer_norm(input, normalized_shape, weight, bias, eps, torch.backends.cudnn.enabled)
RuntimeError: expected scalar type Float but found Half
I fixed this issue.