### PR TITLE
BoostTrack 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11']
-        tracker: ["ocsort", "bytetrack", "botsort", "hybridsort", "deepocsort", "imprassoc", "strongsort"]
+        tracker: ["ocsort", "bytetrack", "botsort", "hybridsort", "deepocsort", "imprassoc", "strongsort", "boosttrack"]
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     outputs:
       status: ${{ job.status }}
     env:
-      TRACKERS: "ocsort bytetrack botsort hybridsort deepocsort imprassoc strongsort"
+      TRACKERS: "ocsort bytetrack botsort hybridsort deepocsort imprassoc strongsort boosttrack"
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 50

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ dist/
 
 # cmc debug images
 boxmot/motion/cmc/*.jpg
+
+# json outputs
+*_output.json

--- a/boxmot/__init__.py
+++ b/boxmot/__init__.py
@@ -11,10 +11,11 @@ from boxmot.trackers.hybridsort.hybridsort import HybridSort
 from boxmot.trackers.ocsort.ocsort import OcSort
 from boxmot.trackers.strongsort.strongsort import StrongSort
 from boxmot.trackers.imprassoc.imprassoctrack import ImprAssocTrack
+from boxmot.trackers.boosttrack.boosttrack import BoostTrack
 
 
-TRACKERS = ['bytetrack', 'botsort', 'strongsort', 'ocsort', 'deepocsort', 'hybridsort', 'imprassoc']
+TRACKERS = ['bytetrack', 'botsort', 'strongsort', 'ocsort', 'deepocsort', 'hybridsort', 'imprassoc', 'boosttrack']
 
 __all__ = ("__version__",
-           "StrongSort", "OcSort", "ByteTrack", "BotSort", "DeepOcSort", "HybridSort", "ImprAssocTrack"
+           "StrongSort", "OcSort", "ByteTrack", "BotSort", "DeepOcSort", "HybridSort", "ImprAssocTrack", "BoostTrack",
            "create_tracker", "get_tracker_config", "gsi")

--- a/boxmot/appearance/backends/base_backend.py
+++ b/boxmot/appearance/backends/base_backend.py
@@ -78,7 +78,7 @@ class BaseModelBackend:
             features = self.inference_postprocess(features)
         else:
             features = np.array([])
-        features = features / np.linalg.norm(features)
+        features = features / np.linalg.norm(features, axis=-1, keepdims=True)
         return features
 
     def warmup(self, imgsz=[(256, 128, 3)]):

--- a/boxmot/configs/boosttrack.yaml
+++ b/boxmot/configs/boosttrack.yaml
@@ -1,0 +1,90 @@
+max_age:
+  type: uniform
+  default: 60
+  range: [15, 90]
+
+min_hits:
+  type: uniform
+  default: 3
+  range: [1, 5]
+
+det_thresh:
+  type: uniform
+  default: 0.6
+  range: [0.1, 0.9]
+
+iou_threshold:
+  type: uniform
+  default: 0.3
+  range: [0.1, 0.9]
+
+use_ecc:
+  type: choice
+  default: True
+  options: [False, True]
+
+min_box_area:
+  type: uniform
+  default: 10
+  range: [5, 100]
+
+aspect_ratio_thresh:
+  type: uniform
+  default: 1.6
+  range: [0.1, 2.0]
+
+lambda_iou:
+  type: uniform
+  default: 0.5
+  range: [0.3, 2.0]
+
+lambda_mhd:
+  type: uniform
+  default: 0.25
+  range: [0.5, 2.0]
+
+lambda_shape:
+  type: uniform
+  default: 0.25
+  range: [0.5, 2.0]
+
+use_dlo_boost:
+  type: choice
+  default: True
+  options: [False, True]
+
+use_duo_boost:
+  type: choice
+  default: True
+  options: [False, True]
+
+dlo_boost_coef:
+  type: uniform
+  default: 0.65
+  range: [0.3, 2.0]
+
+s_sim_corr:
+  type: choice
+  default: False
+  options: [False, True]
+
+use_rich_s:
+  type: choice
+  default: False
+  options: [False, True]
+
+use_sb:
+  type: choice
+  default: False
+  options: [False, True]
+
+use_vt:
+  type: choice
+  default: False
+  options: [False, True]
+
+with_reid:
+  type: choice
+  default: False
+  options: [False, True]
+

--- a/boxmot/configs/boosttrack.yaml
+++ b/boxmot/configs/boosttrack.yaml
@@ -70,21 +70,21 @@ s_sim_corr:
 
 use_rich_s:
   type: choice
-  default: False
+  default: True # True for BoostTrack++
   options: [False, True]
 
 use_sb:
   type: choice
-  default: False
+  default: True # True for BoostTrack++
   options: [False, True]
 
 use_vt:
   type: choice
-  default: False
+  default: True # True for BoostTrack++
   options: [False, True]
 
 with_reid:
   type: choice
-  default: False
+  default: True # True for BoostTrack+ and BoostTrack++
   options: [False, True]
 

--- a/boxmot/tracker_zoo.py
+++ b/boxmot/tracker_zoo.py
@@ -47,7 +47,8 @@ def create_tracker(tracker_type, tracker_config=None, reid_weights=None, device=
         'botsort': 'boxmot.trackers.botsort.botsort.BotSort',
         'deepocsort': 'boxmot.trackers.deepocsort.deepocsort.DeepOcSort',
         'hybridsort': 'boxmot.trackers.hybridsort.hybridsort.HybridSort',
-        'imprassoc': 'boxmot.trackers.imprassoc.imprassoctrack.ImprAssocTrack'
+        'imprassoc': 'boxmot.trackers.imprassoc.imprassoctrack.ImprAssocTrack',
+        'boosttrack': 'boxmot.trackers.boosttrack.boosttrack.BoostTrack',
     }
 
     # Check if the tracker type exists in the mapping
@@ -60,10 +61,10 @@ def create_tracker(tracker_type, tracker_config=None, reid_weights=None, device=
     tracker_class = getattr(__import__(module_path, fromlist=[class_name]), class_name)
     
     # For specific trackers, update tracker arguments with ReID parameters
-    if tracker_type in ['strongsort', 'botsort', 'deepocsort', 'hybridsort', 'imprassoc']:
+    if tracker_type in ['strongsort', 'botsort', 'deepocsort', 'hybridsort', 'imprassoc', 'boosttrack']:
         tracker_args['per_class'] = per_class
         tracker_args.update(reid_args)
-        if tracker_type == 'strongsort':
+        if tracker_type in ['strongsort', 'boosttrack']:
             tracker_args.pop('per_class')  # per class not supported by
     else:
         tracker_args['per_class'] = per_class

--- a/boxmot/trackers/boosttrack/assoc.py
+++ b/boxmot/trackers/boosttrack/assoc.py
@@ -1,0 +1,209 @@
+import warnings
+from copy import deepcopy
+from typing import Optional
+
+import lap
+import numpy as np
+
+
+def shape_similarity(detects: np.ndarray, tracks: np.ndarray, s_sim_corr: bool) -> np.ndarray:
+    if not s_sim_corr:
+        return shape_similarity_v1(detects, tracks)
+    else:
+        return shape_similarity_v2(detects, tracks)
+
+def shape_similarity_v1(detects: np.ndarray, tracks: np.ndarray) -> np.ndarray:
+    if detects.size == 0 or tracks.size == 0:
+        return np.zeros((0, 0))
+
+    dw = (detects[:, 2] - detects[:, 0]).reshape((-1, 1))
+    dh = (detects[:, 3] - detects[:, 1]).reshape((-1, 1))
+    tw = (tracks[:, 2] - tracks[:, 0]).reshape((1, -1))
+    th = (tracks[:, 3] - tracks[:, 1]).reshape((1, -1))
+    return np.exp(-(np.abs(dw - tw)/np.maximum(dw, tw) + np.abs(dh - th)/np.maximum(dw, tw)))
+
+
+def shape_similarity_v2(detects: np.ndarray, tracks: np.ndarray) -> np.ndarray:
+    if detects.size == 0 or tracks.size == 0:
+        return np.zeros((0, 0))
+
+    dw = (detects[:, 2] - detects[:, 0]).reshape((-1, 1))
+    dh = (detects[:, 3] - detects[:, 1]).reshape((-1, 1))
+    tw = (tracks[:, 2] - tracks[:, 0]).reshape((1, -1))
+    th = (tracks[:, 3] - tracks[:, 1]).reshape((1, -1))
+    return np.exp(-(np.abs(dw - tw)/np.maximum(dw, tw) + np.abs(dh - th)/np.maximum(dh, th)))
+
+
+def MhDist_similarity(mahalanobis_distance: np.ndarray, softmax_temp: float = 1.0) -> np.ndarray:
+    limit = 13.2767  # 99% conf interval https://www.mathworks.com/help/stats/chi2inv.html
+    mahalanobis_distance = deepcopy(mahalanobis_distance)
+    mask = mahalanobis_distance > limit
+    mahalanobis_distance[mask] = limit
+    mahalanobis_distance = limit - mahalanobis_distance
+
+    mahalanobis_distance = np.exp(mahalanobis_distance/softmax_temp) / np.exp(mahalanobis_distance/softmax_temp).sum(0).reshape((1, -1))
+    mahalanobis_distance = np.where(mask, 0, mahalanobis_distance)
+    return mahalanobis_distance
+
+
+def iou_batch(bboxes1, bboxes2):
+    """
+    From SORT: Computes IOU between two bboxes in the form [x1,y1,x2,y2]
+    """
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+
+    xx1 = np.maximum(bboxes1[..., 0], bboxes2[..., 0])
+    yy1 = np.maximum(bboxes1[..., 1], bboxes2[..., 1])
+    xx2 = np.minimum(bboxes1[..., 2], bboxes2[..., 2])
+    yy2 = np.minimum(bboxes1[..., 3], bboxes2[..., 3])
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
+    wh = w * h
+    o = wh / (
+        (bboxes1[..., 2] - bboxes1[..., 0]) * (bboxes1[..., 3] - bboxes1[..., 1])
+        + (bboxes2[..., 2] - bboxes2[..., 0]) * (bboxes2[..., 3] - bboxes2[..., 1])
+        - wh
+    )
+
+    return o
+
+
+def soft_biou_batch(bboxes1, bboxes2):
+    """
+    Computes soft BIoU between two bboxes in the form [x1,y1,x2,y2]
+    BIoU is introduced in https://arxiv.org/pdf/2211.14317
+    Soft BIoU is introduced as part of BoostTrack++
+    # Author : Vukasin Stanojevic
+    # Email  : vukasin.stanojevic@pmf.edu.rs
+    """
+
+    bboxes2 = np.expand_dims(bboxes2, 0)
+    bboxes1 = np.expand_dims(bboxes1, 1)
+    k1 = 0.25
+    k2 = 0.5
+    b2conf = bboxes2[..., 4]
+    b1x1 = bboxes1[..., 0] - (bboxes1[..., 2]-bboxes1[..., 0]) * (1-b2conf)*k1
+    b2x1 = bboxes2[..., 0] - (bboxes2[..., 2]-bboxes2[..., 0]) * (1-b2conf)*k2
+    xx1 = np.maximum(b1x1, b2x1)
+
+    b1y1 = bboxes1[..., 1] - (bboxes1[..., 3]-bboxes1[..., 1]) * (1-b2conf)*k1
+    b2y1 = bboxes2[..., 1] - (bboxes2[..., 3]-bboxes2[..., 1]) * (1-b2conf)*k2
+    yy1 = np.maximum(b1y1, b2y1)
+
+    b1x2 = bboxes1[..., 2] + (bboxes1[..., 2]-bboxes1[..., 0]) * (1-b2conf)*k1
+    b2x2 = bboxes2[..., 2] + (bboxes2[..., 2]-bboxes2[..., 0]) * (1-b2conf)*k2
+    xx2 = np.minimum(b1x2, b2x2)
+
+    b1y2 = bboxes1[..., 3] + (bboxes1[..., 3]-bboxes1[..., 1]) * (1-b2conf)*k1
+    b2y2 = bboxes2[..., 3] + (bboxes2[..., 3]-bboxes2[..., 1]) * (1-b2conf)*k2
+    yy2 = np.minimum(b1y2, b2y2)
+
+    w = np.maximum(0.0, xx2 - xx1)
+    h = np.maximum(0.0, yy2 - yy1)
+    wh = w * h
+
+    o = wh / (
+        (b1x2 - b1x1) * (b1y2 - b1y1)
+        + (b2x2 - b2x1) * (b2y2 - b2y1)
+        - wh
+    )
+
+    return o
+
+
+def match(cost_matrix: np.ndarray, threshold: float) -> np.ndarray:
+    if cost_matrix.size > 0:
+        a = (cost_matrix > threshold).astype(np.int32)
+        if a.sum(1).max() == 1 and a.sum(0).max() == 1:
+            matched_indices = np.stack(np.where(a), axis=1)
+        else:
+            _, x, y = lap.lapjv(-cost_matrix, extend_cost=True)
+            matched_indices = np.array([[y[i], i] for i in x if i >= 0])
+    else:
+        matched_indices = np.empty(shape=(0, 2))
+    return matched_indices
+
+
+def linear_assignment(detections: np.ndarray, trackers: np.ndarray,
+                      iou_matrix: np.ndarray, cost_matrix: np.ndarray,
+                      threshold: float, emb_cost: Optional[np.ndarray] = None):
+    if iou_matrix is None and cost_matrix is None:
+        raise Exception("Both iou_matrix and cost_matrix are None!")
+    if iou_matrix is None:
+        iou_matrix = deepcopy(cost_matrix)
+    if cost_matrix is None:
+        cost_matrix = deepcopy(iou_matrix)
+    matched_indices = match(cost_matrix, threshold)
+    unmatched_detections = []
+    for d, det in enumerate(detections):
+        if d not in matched_indices[:, 0]:
+            unmatched_detections.append(d)
+    unmatched_trackers = []
+    for t, trk in enumerate(trackers):
+        if t not in matched_indices[:, 1]:
+            unmatched_trackers.append(t)
+
+    # filter out matched with low IOU
+    matches = []
+    for m in matched_indices:
+        valid_match = iou_matrix[m[0], m[1]] >= threshold  or (False if emb_cost is None else (iou_matrix[m[0], m[1]] >= threshold / 2 and emb_cost[m[0], m[1]] >= 0.75))
+        if valid_match:
+            matches.append(m.reshape(1, 2))
+        else:
+            unmatched_detections.append(m[0])
+            unmatched_trackers.append(m[1])
+
+    if len(matches) == 0:
+        matches = np.empty((0, 2), dtype=int)
+    else:
+        matches = np.concatenate(matches, axis=0)
+
+    return matches, np.array(unmatched_detections), np.array(unmatched_trackers), cost_matrix
+
+
+def associate(
+        detections,
+        trackers,
+        iou_threshold,
+        mahalanobis_distance: Optional[np.ndarray] = None,
+        track_confidence: Optional[np.ndarray] = None,
+        detection_confidence: Optional[np.ndarray] = None,
+        emb_cost: Optional[np.ndarray] = None,
+        lambda_iou: float = 0.5,
+        lambda_mhd: float = 0.25,
+        lambda_shape: float = 0.25,
+        s_sim_corr: bool = False,
+):
+    if len(trackers) == 0:
+        return (
+            np.empty((0, 2), dtype=int),
+            np.arange(len(detections)),
+            np.empty((0, 5), dtype=int),
+            np.empty((0, 0))
+        )
+    iou_matrix = iou_batch(detections, trackers)
+
+    cost_matrix = deepcopy(iou_matrix)
+
+    if detection_confidence is not None and track_confidence is not None:
+        conf = np.multiply(detection_confidence.reshape((-1, 1)), track_confidence.reshape((1, -1)))
+        conf[iou_matrix < iou_threshold] = 0
+
+        cost_matrix += lambda_iou * conf * iou_batch(detections, trackers)
+    else:
+        warnings.warn("Detections or tracklet confidence is None and detection-tracklet confidence cannot be computed!")
+        conf = None
+
+    if mahalanobis_distance is not None and mahalanobis_distance.size > 0:
+        mahalanobis_distance = MhDist_similarity(mahalanobis_distance)
+
+        cost_matrix += lambda_mhd * mahalanobis_distance
+        if conf is not None:
+            cost_matrix += lambda_shape * conf * shape_similarity(detections, trackers, s_sim_corr)
+
+    if emb_cost is not None:
+        lambda_emb = (1+lambda_iou+lambda_shape+lambda_mhd) * 1.5
+        cost_matrix += lambda_emb * emb_cost
+
+    return linear_assignment(detections, trackers, iou_matrix, cost_matrix, iou_threshold, emb_cost)

--- a/boxmot/trackers/boosttrack/boosttrack.py
+++ b/boxmot/trackers/boosttrack/boosttrack.py
@@ -107,29 +107,29 @@ class BoostTrack:
         device,
         half: bool,
 
-        max_age: int,
-        min_hits: int,
-        det_thresh: float,
-        iou_threshold: float,
-        use_ecc: bool,
-        min_box_area: int,
-        aspect_ratio_thresh: 1.6,
+        max_age: int = 60,
+        min_hits: int = 3,
+        det_thresh: float = 0.6,
+        iou_threshold: float = 0.3,
+        use_ecc: bool = True,
+        min_box_area: int = 10,
+        aspect_ratio_thresh: bool = 1.6,
 
         # BoostTrack parameters
-        lambda_iou: float,
-        lambda_mhd: float,
-        lambda_shape: float,
-        use_dlo_boost: bool,
-        use_duo_boost: bool,
-        dlo_boost_coef: float,
-        s_sim_corr: bool,
+        lambda_iou: float = 0.5,
+        lambda_mhd: float = 0.25,
+        lambda_shape: float = 0.25,
+        use_dlo_boost: bool = True,
+        use_duo_boost: bool = True,
+        dlo_boost_coef: float = 0.65,
+        s_sim_corr: bool = False,
     
         # BoostTrack++ parameters
-        use_rich_s: bool,
-        use_sb: bool,
-        use_vt: bool,
+        use_rich_s: bool = False,
+        use_sb: bool = False,
+        use_vt: bool = False,
 
-        with_reid: bool = True,
+        with_reid: bool = False,
     ):
         self.frame_count = 0
         self.trackers: List[KalmanBoxTracker] = []

--- a/boxmot/trackers/boosttrack/boosttrack.py
+++ b/boxmot/trackers/boosttrack/boosttrack.py
@@ -1,0 +1,369 @@
+import numpy as np
+from copy import deepcopy
+from typing import Optional, List
+import cv2
+
+from boxmot.trackers.boosttrack.assoc import (
+    associate,
+    iou_batch,
+    MhDist_similarity,
+    shape_similarity,
+    soft_biou_batch,
+)
+from boxmot.trackers.boosttrack.kalmanfilter import KalmanFilter
+from boxmot.trackers.boosttrack.ecc import ECC
+from boxmot.appearance.reid_auto_backend import ReidAutoBackend
+
+
+def convert_bbox_to_z(bbox):
+    """
+    Converts a bounding box [x1,y1,x2,y2] to state vector [x, y, h, r].
+    """
+    w = bbox[2] - bbox[0]
+    h = bbox[3] - bbox[1]
+    x = bbox[0] + w / 2.0
+    y = bbox[1] + h / 2.0
+    r = w / float(h + 1e-6)
+    return np.array([x, y, h, r]).reshape((4, 1))
+
+
+def convert_x_to_bbox(x, score=None):
+    """
+    Converts a state vector [x, y, h, r] back to bounding box [x1,y1,x2,y2].
+    """
+    h = x[2]
+    r = x[3]
+    w = 0 if r <= 0 else r * h
+    if score is None:
+        return np.array([x[0] - w / 2.0, x[1] - h / 2.0,
+                         x[0] + w / 2.0, x[1] + h / 2.0]).reshape((1, 4))
+    else:
+        return np.array([x[0] - w / 2.0, x[1] - h / 2.0,
+                         x[0] + w / 2.0, x[1] + h / 2.0, score]).reshape((1, 5))
+
+
+class KalmanBoxTracker:
+    """
+    Single object tracker using a Kalman filter.
+    """
+    count = 0
+
+    def __init__(self, bbox, emb: Optional[np.ndarray] = None):
+        self.bbox_to_z_func = convert_bbox_to_z
+        self.x_to_bbox_func = convert_x_to_bbox
+
+        self.time_since_update = 0
+        self.id = KalmanBoxTracker.count
+        KalmanBoxTracker.count += 1
+
+        self.kf = KalmanFilter(self.bbox_to_z_func(bbox))
+        self.emb = emb
+        self.hit_streak = 0
+        self.age = 0
+
+    def get_confidence(self, coef: float = 0.9) -> float:
+        n = 7
+        if self.age < n:
+            return coef ** (n - self.age)
+        return coef ** (self.time_since_update - 1)
+
+    def update(self, bbox: np.ndarray, score: float = 0):
+        self.time_since_update = 0
+        self.hit_streak += 1
+        self.kf.update(self.bbox_to_z_func(bbox), score)
+
+    def camera_update(self, transform: np.ndarray):
+        x1, y1, x2, y2 = self.get_state()[0]
+        x1_, y1_, _ = transform @ np.array([x1, y1, 1]).T
+        x2_, y2_, _ = transform @ np.array([x2, y2, 1]).T
+        w, h = x2_ - x1_, y2_ - y1_
+        cx, cy = x1_ + w / 2, y1_ + h / 2
+        self.kf.x[:4] = [cx, cy, h, w / h]
+
+    def predict(self):
+        self.kf.predict()
+        self.age += 1
+        if self.time_since_update > 0:
+            self.hit_streak = 0
+        self.time_since_update += 1
+        return self.get_state()
+
+    def get_state(self):
+        return self.x_to_bbox_func(self.kf.x)
+
+    def update_emb(self, emb, alpha=0.9):
+        self.emb = alpha * self.emb + (1 - alpha) * emb
+        self.emb /= np.linalg.norm(self.emb)
+
+    def get_emb(self):
+        return self.emb
+
+
+class BoostTrack:
+
+    def __init__(
+        self,
+        reid_weights,
+        device,
+        half: bool,
+
+        max_age: int,
+        min_hits: int,
+        det_thresh: float,
+        iou_threshold: float,
+        use_ecc: bool,
+        min_box_area: int,
+        aspect_ratio_thresh: 1.6,
+
+        # BoostTrack parameters
+        lambda_iou: float,
+        lambda_mhd: float,
+        lambda_shape: float,
+        use_dlo_boost: bool,
+        use_duo_boost: bool,
+        dlo_boost_coef: float,
+        s_sim_corr: bool,
+    
+        # BoostTrack++ parameters
+        use_rich_s: bool,
+        use_sb: bool,
+        use_vt: bool,
+
+        with_reid: bool = True,
+    ):
+        self.frame_count = 0
+        self.trackers: List[KalmanBoxTracker] = []
+
+        # Parameters for BoostTrack (these can be tuned as needed)
+        self.max_age = max_age            # maximum allowed frames without update
+        self.min_hits = min_hits          # minimum hits to output a track
+        self.det_thresh = det_thresh      # detection confidence threshold
+        self.iou_threshold = iou_threshold   # association IoU threshold
+        self.use_ecc = use_ecc            # use ECC for camera motion compensation
+        self.min_box_area = min_box_area  # minimum box area for detections
+        self.aspect_ratio_thresh = aspect_ratio_thresh  # aspect ratio threshold for detections
+
+        self.lambda_iou = lambda_iou
+        self.lambda_mhd = lambda_mhd
+        self.lambda_shape = lambda_shape
+        self.use_dlo_boost = use_dlo_boost
+        self.use_duo_boost = use_duo_boost
+        self.dlo_boost_coef = dlo_boost_coef
+        self.s_sim_corr = s_sim_corr
+
+        self.use_rich_s = use_rich_s
+        self.use_sb = use_sb
+        self.use_vt = use_vt
+    
+        self.with_reid = with_reid
+
+        if self.with_reid:
+            self.reid_model = ReidAutoBackend(weights=reid_weights, device=device, half=half).model
+        else:
+            self.reid_model = None
+
+        if self.use_ecc:
+            self.ecc = ECC(scale=350, video_name=None, use_cache=True)
+        else:
+            self.ecc = None
+
+    def update(self, dets: np.ndarray, img: np.ndarray, embs: Optional[np.ndarray] = None) -> np.ndarray:
+        """
+        Update the tracker with detections and an image.
+        
+        Args:
+          dets (np.ndarray): Detection boxes in the format [[x1,y1,x2,y2,score], ...]
+          img (np.ndarray): The current image frame.
+          embs (Optional[np.ndarray]): Optional precomputed embeddings.
+          
+        Returns:
+          np.ndarray: Tracked objects in the format
+                      [x1, y1, x2, y2, id, confidence, cls, det_ind]
+                      (with cls and det_ind set to -1 if unused)
+        """
+        if dets is None:
+            return np.empty((0, 5))
+        if not isinstance(dets, np.ndarray):
+            dets = dets.cpu().detach().numpy()
+
+        self.frame_count += 1
+
+        if self.ecc is not None:
+            transform = self.ecc(img, self.frame_count)
+            for trk in self.trackers:
+                trk.camera_update(transform)
+
+        trks = []
+        confs = []
+        
+        for trk in self.trackers:
+            pos = trk.predict()[0]
+            conf = trk.get_confidence()
+            confs.append(conf)
+            trks.append(np.concatenate([pos, [conf]]))
+        trks_np = np.vstack(trks) if len(trks) > 0 else np.empty((0, 5))
+
+        if self.use_dlo_boost:
+            dets = self.dlo_confidence_boost(dets)
+        if self.use_duo_boost:
+            dets = self.duo_confidence_boost(dets)
+
+        valid_inds = dets[:, 4] >= self.det_thresh
+        dets = dets[valid_inds]
+        scores = dets[:, 4]
+
+        if self.with_reid and dets.shape[0] > 0:
+            dets_embs = self.reid_model.get_features(dets[:, :4], img)
+        else:
+            dets_embs = np.ones((dets.shape[0], 1))
+
+        if self.with_reid and len(self.trackers) > 0:
+            tracker_embs = np.array([trk.get_emb() for trk in self.trackers])
+            emb_cost = dets_embs @ tracker_embs.T
+        else:
+            emb_cost = None
+
+        mh_dist_matrix = self.get_mh_dist_matrix(dets)
+
+        matched, unmatched_dets, unmatched_trks, _ = associate(
+            dets,
+            trks_np,
+            self.iou_threshold,
+            mahalanobis_distance=mh_dist_matrix,
+            track_confidence=np.array(confs).reshape(-1, 1),
+            detection_confidence=scores,
+            emb_cost=emb_cost,
+            lambda_iou=self.lambda_iou,
+            lambda_mhd=self.lambda_mhd,
+            lambda_shape=self.lambda_shape,
+            s_sim_corr=self.s_sim_corr
+        )
+
+        trust = (dets[:, 4] - self.det_thresh) / (1 - self.det_thresh)
+        af = 0.95
+        dets_alpha = af + (1 - af) * (1 - trust)
+
+        for m in matched:
+            self.trackers[m[1]].update(dets[m[0], :], scores[m[0]])
+            self.trackers[m[1]].update_emb(dets_embs[m[0]], alpha=dets_alpha[m[0]])
+
+        for i in unmatched_dets:
+            if dets[i, 4] >= self.det_thresh:
+                self.trackers.append(KalmanBoxTracker(dets[i, :], emb=dets_embs[i]))
+
+        outputs = []
+        for trk in self.trackers:
+            d = trk.get_state()[0]
+            if (trk.time_since_update < 1) and (trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
+                # Format to match BotSort output: [x1, y1, x2, y2, id, confidence, cls, det_ind]
+                outputs.append(np.array([d[0], d[1], d[2], d[3], trk.id + 1, trk.get_confidence(), -1, -1]))
+            
+        self.trackers = [trk for trk in self.trackers if trk.time_since_update <= self.max_age]
+
+        if len(outputs) > 0:
+            outputs = np.vstack(outputs)
+            return self.filter_outputs(outputs)
+        return np.empty((0, 8))
+    
+
+    def filter_outputs(self, outputs: np.ndarray) -> np.ndarray:
+
+        w_arr = outputs[:, 2] - outputs[:, 0]
+        h_arr = outputs[:, 3] - outputs[:, 1]
+
+        vertical_filter = w_arr / h_arr <= self.aspect_ratio_thresh
+        area_filter = w_arr * h_arr > self.min_box_area
+
+        return outputs[vertical_filter & area_filter]
+    
+    def dump_cache(self):
+        if self.ecc is not None:
+            self.ecc.save_cache()
+    
+    def get_iou_matrix(self, detections: np.ndarray, buffered: bool = False) -> np.ndarray:
+        trackers = np.zeros((len(self.trackers), 5))
+        for t, trk in enumerate(trackers):
+            pos = self.trackers[t].get_state()[0]
+            trk[:] = [pos[0], pos[1], pos[2], pos[3], self.trackers[t].get_confidence()]
+
+        return iou_batch(detections, trackers) if not buffered else soft_biou_batch(detections, trackers)
+
+    def get_mh_dist_matrix(self, detections: np.ndarray, n_dims: int = 4) -> np.ndarray:
+        if len(self.trackers) == 0:
+            return np.zeros((0, 0))
+        z = np.zeros((len(detections), n_dims), dtype=float)
+        x = np.zeros((len(self.trackers), n_dims), dtype=float)
+        sigma_inv = np.zeros((len(self.trackers), n_dims), dtype=float)
+
+        for i in range(len(detections)):
+            z[i, :n_dims] = convert_bbox_to_z(detections[i, :]).reshape(-1)[:n_dims]
+        for i, trk in enumerate(self.trackers):
+            x[i] = trk.kf.x[:n_dims]
+            sigma_inv[i] = np.reciprocal(np.diag(trk.kf.covariance[:n_dims, :n_dims]))
+        return ((z.reshape((-1, 1, n_dims)) - x.reshape((1, -1, n_dims))) ** 2 *
+                sigma_inv.reshape((1, -1, n_dims))).sum(axis=2)
+
+    def duo_confidence_boost(self, detections: np.ndarray) -> np.ndarray:
+        n_dims = 4
+        limit = 13.2767
+        mh_dist = self.get_mh_dist_matrix(detections, n_dims)
+        if mh_dist.size > 0 and self.frame_count > 1:
+            min_dists = mh_dist.min(1)
+            mask = (min_dists > limit) & (detections[:, 4] < self.det_thresh)
+            boost_inds = np.where(mask)[0]
+            iou_limit = 0.3
+            if len(boost_inds) > 0:
+                bdiou = iou_batch(detections[boost_inds], detections[boost_inds]) - np.eye(len(boost_inds))
+                bdiou_max = bdiou.max(axis=1)
+                remaining = boost_inds[bdiou_max <= iou_limit]
+                args = np.where(bdiou_max > iou_limit)[0]
+                for i in range(len(args)):
+                    bi = args[i]
+                    tmp = np.where(bdiou[bi] > iou_limit)[0]
+                    args_tmp = np.append(np.intersect1d(boost_inds[args], boost_inds[tmp]), boost_inds[bi])
+                    conf_max = np.max(detections[args_tmp, 4])
+                    if detections[boost_inds[bi], 4] == conf_max:
+                        remaining = np.concatenate([remaining, [boost_inds[bi]]])
+                mask_boost = np.zeros_like(detections[:, 4], dtype=bool)
+                mask_boost[remaining] = True
+                detections[:, 4] = np.where(mask_boost, self.det_thresh + 1e-4, detections[:, 4])
+        return detections
+
+    def dlo_confidence_boost(self, detections: np.ndarray) -> np.ndarray:
+        sbiou_matrix = self.get_iou_matrix(detections, True)
+        if sbiou_matrix.size == 0:
+            return detections
+
+        trackers = np.zeros((len(self.trackers), 6))
+        for t, trk in enumerate(self.trackers):
+            pos = trk.get_state()[0]
+            trackers[t] = [pos[0], pos[1], pos[2], pos[3], 0, trk.time_since_update - 1]
+
+        if self.use_rich_s:
+            mhd_sim = MhDist_similarity(self.get_mh_dist_matrix(detections), 1)
+            shape_sim = shape_similarity(detections, trackers)
+            S = (mhd_sim + shape_sim + sbiou_matrix) / 3
+        else:
+            S = self.get_iou_matrix(detections, False)
+
+        if not self.use_sb and not self.use_vt:
+            max_s = S.max(1)
+            detections[:, 4] = np.maximum(detections[:, 4], max_s * self.dlo_boost_coef)
+        else:
+            if self.use_sb:
+                max_s = S.max(1)
+                alpha = 0.65
+                detections[:, 4] = np.maximum(
+                    detections[:, 4], 
+                    alpha * detections[:, 4] + (1 - alpha) * max_s ** 1.5)
+            if self.use_vt:
+                threshold_s = 0.95
+                threshold_e = 0.8
+                n_steps = 20
+                alpha = (threshold_s - threshold_e) / n_steps
+                tmp = (S > np.maximum(threshold_s - np.array([trk.time_since_update - 1 for trk in self.trackers]),
+                                        threshold_e)).max(1)
+                scores = detections[:, 4].copy()
+                scores[tmp] = np.maximum(scores[tmp], self.det_thresh + 1e-5)
+                detections[:, 4] = scores
+        return detections

--- a/boxmot/trackers/boosttrack/ecc.py
+++ b/boxmot/trackers/boosttrack/ecc.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# Author : HuangPiao
+# Email  : huangpiao2985@163.com
+# Date   : 3/11/2019
+
+from __future__ import division
+
+from copy import deepcopy
+from typing import Optional, Dict
+
+import numpy as np
+import cv2
+import os
+import json
+
+
+def ecc(src, dst, warp_mode = cv2.MOTION_EUCLIDEAN, eps = 1e-5,
+        max_iter = 100, scale = 0.1, align = False):
+    """Compute the warp matrix from src to dst.
+
+    Parameters
+    ----------
+    src : ndarray
+        An NxM matrix of source img(BGR or Gray), it must be the same format as dst.
+    dst : ndarray
+        An NxM matrix of target img(BGR or Gray).
+    warp_mode: flags of opencv
+        translation: cv2.MOTION_TRANSLATION
+        rotated and shifted: cv2.MOTION_EUCLIDEAN
+        affine(shift,rotated,shear): cv2.MOTION_AFFINE
+        homography(3d): cv2.MOTION_HOMOGRAPHY
+    eps: float
+        the threshold of the increment in the correlation coefficient between two iterations
+    max_iter: int
+        the number of iterations.
+    scale: float or [int, int]
+        scale_ratio: float
+        scale_size: [W, H]
+    align: bool
+        whether to warp affine or perspective transforms to the source image
+
+    Returns
+    -------
+    warp matrix : ndarray
+        Returns the warp matrix from src to dst.
+        if motion models is homography, the warp matrix will be 3x3, otherwise 2x3
+    src_aligned: ndarray
+        aligned source image of gray
+    """
+    assert src.shape == dst.shape, "the source image must be the same format to the target image!"
+
+    # BGR2GRAY
+    if src.ndim == 3:
+        # Convert images to grayscale
+        src = cv2.cvtColor(src, cv2.COLOR_BGR2GRAY)
+        dst = cv2.cvtColor(dst, cv2.COLOR_BGR2GRAY)
+
+    # make the imgs smaller to speed up
+    if scale is not None:
+        if isinstance(scale, float):
+            if scale != 1:
+                src_r = cv2.resize(src, (0, 0), fx = scale, fy = scale,interpolation =  cv2.INTER_LINEAR)
+                dst_r = cv2.resize(dst, (0, 0), fx = scale, fy = scale,interpolation =  cv2.INTER_LINEAR)
+                scale = [scale, scale]
+            else:
+                src_r, dst_r = src, dst
+                scale = None
+        elif isinstance(scale, int):
+            scale = scale / src.shape[1]
+            src_r = cv2.resize(src, (0, 0), fx=scale, fy=scale, interpolation=cv2.INTER_LINEAR)
+            dst_r = cv2.resize(dst, (0, 0), fx=scale, fy=scale, interpolation=cv2.INTER_LINEAR)
+            scale = [scale, scale]
+        else:
+            if scale[0] != src.shape[1] and scale[1] != src.shape[0]:
+                src_r = cv2.resize(src, (scale[0], scale[1]), interpolation = cv2.INTER_LINEAR)
+                dst_r = cv2.resize(dst, (scale[0], scale[1]), interpolation=cv2.INTER_LINEAR)
+                scale = [scale[0] / src.shape[1], scale[1] / src.shape[0]]
+            else:
+                src_r, dst_r = src, dst
+                scale = None
+    else:
+        src_r, dst_r = src, dst
+
+    # Define 2x3 or 3x3 matrices and initialize the matrix to identity
+    if warp_mode == cv2.MOTION_HOMOGRAPHY :
+        warp_matrix = np.eye(3, 3, dtype=np.float32)
+    else :
+        warp_matrix = np.eye(2, 3, dtype=np.float32)
+
+    # Define termination criteria
+    criteria = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, max_iter, eps)
+
+    # Run the ECC algorithm. The results are stored in warp_matrix.
+    (cc, warp_matrix) = cv2.findTransformECC (src_r, dst_r, warp_matrix, warp_mode, criteria, None, 1)
+
+    if scale is not None:
+        warp_matrix[0, 2] = warp_matrix[0, 2] / scale[0]
+        warp_matrix[1, 2] = warp_matrix[1, 2] / scale[1]
+
+    if align:
+        sz = src.shape
+        if warp_mode == cv2.MOTION_HOMOGRAPHY:
+            # Use warpPerspective for Homography
+            src_aligned = cv2.warpPerspective(src, warp_matrix, (sz[1],sz[0]), flags=cv2.INTER_LINEAR)
+        else :
+            # Use warpAffine for Translation, Euclidean and Affine
+            src_aligned = cv2.warpAffine(src, warp_matrix, (sz[1],sz[0]), flags=cv2.INTER_LINEAR)
+        return warp_matrix, src_aligned
+    else:
+        return warp_matrix, None
+
+
+class ECC:
+
+    def __init__(self, warp_mode = cv2.MOTION_EUCLIDEAN, eps = 1e-4,
+        max_iter = 100, scale = 0.15, align = False,
+        video_name: Optional[str] = None, use_cache: bool = True):
+        self.wrap_mode = warp_mode
+        self.eps = eps
+        self.max_iter = max_iter
+        self.scale = scale
+        self.align = align
+        self.prev_image: Optional[np.ndarray] = None
+        self.video_name = video_name
+        self.use_cache = use_cache
+        self.cache: Dict[str, np.ndarray] = dict()
+        if self.use_cache and self.video_name is not None and len(self.video_name) > 0:
+            try:
+                self.cache = json.load(open(os.path.join("cache", self.video_name + ".json"), 'r'))
+                for k in self.cache:
+                    self.cache[k] = np.array(self.cache[k])
+                if len(self.cache) > 1:
+                    print("USING CMC CACHE!")
+            except:
+                pass
+
+    def __call__(self, np_image: np.ndarray, frame_id: int, video: Optional[str] = "") -> np.ndarray:
+        if frame_id == 1:
+            self.prev_image = deepcopy(np_image)
+            return np.eye(3, dtype=float)
+        key = "{}-{}".format(video, frame_id)
+        if key in self.cache:
+            return self.cache[key]
+
+        result, _ = ecc(self.prev_image, np_image, self.wrap_mode, self.eps, self.max_iter, self.scale, self.align)
+        self.prev_image = deepcopy(np_image)
+        if result.shape == (2, 3):
+            result = np.vstack((result, np.array([[0, 0, 1]], dtype=float)))
+
+        if self.use_cache:
+            self.cache[key] = deepcopy(result)
+
+        return result
+
+    def save_cache(self):
+        if not self.use_cache:
+            return
+        if self.video_name is not None and len(self.video_name) > 0:
+            f = open(os.path.join("cache", self.video_name + ".json"), "w")
+            for k in self.cache:
+                self.cache[k] = self.cache[k].tolist()
+            json.dump(self.cache, f)
+            f.close()

--- a/boxmot/trackers/boosttrack/kalmanfilter.py
+++ b/boxmot/trackers/boosttrack/kalmanfilter.py
@@ -1,0 +1,186 @@
+# vim: expandtab:ts=4:sw=4
+import math
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import scipy.linalg
+
+"""
+Table for the 0.95 quantile of the chi-square distribution with N degrees of
+freedom (contains values for N=1, ..., 9). Taken from MATLAB/Octave's chi2inv
+function and used as Mahalanobis gating threshold.
+"""
+chi2inv95 = {
+    1: 3.8415,
+    2: 5.9915,
+    3: 7.8147,
+    4: 9.4877,
+    5: 11.070,
+    6: 12.592,
+    7: 14.067,
+    8: 15.507,
+    9: 16.919}
+
+
+class CovariancePolicy(ABC):
+
+    def __init__(self, x_dim: int, z_dim: int):
+        self.x_dim = x_dim
+        self.z_dim = z_dim
+
+    @abstractmethod
+    def get_init_state_cov(self, z: np.ndarray) -> np.ndarray:
+        pass
+
+    @abstractmethod
+    def get_R(self, x: np.ndarray, confidence: float = 0.0) -> np.ndarray:
+        ...
+
+    @abstractmethod
+    def get_Q(self, x: np.ndarray) -> np.ndarray:
+        ...
+
+
+class ConstantNoise(CovariancePolicy):
+
+    def get_init_state_cov(self, z: np.ndarray) -> np.ndarray:
+
+        P = np.eye(self.x_dim)
+        P[4:, 4:] *= 1000.0  # give high uncertainty to the unobservable initial velocities
+        P *= 10.0
+
+        return P
+
+    def get_R(self, x: np.ndarray, confidence: float = 0.0) -> np.ndarray:
+        return np.diag([1, 1, 10, 0.01])
+
+    def get_Q(self, x: np.ndarray) -> np.ndarray:
+        Q = np.eye(self.x_dim)
+        Q[4:, 4:] *= 0.01
+
+        return Q
+
+
+class KalmanFilter(object):
+    """
+    A simple Kalman filter for tracking bounding boxes in image space.
+
+    The 8-dimensional state space
+
+        x, y, h, a, vx, vy, vh, va
+
+    contains the bounding box center position (x, y), aspect ratio a, height h,
+    and their respective velocities.
+
+    Object motion follows a constant velocity model. The bounding box location
+    (x, y, h, a) is taken as direct observation of the state space (linear
+    observation model).
+
+    """
+
+    def __init__(self, z: np.ndarray, ndim: int = 8, dt: int = 1,
+                 cov_update_policy: CovariancePolicy = ConstantNoise,
+                 id: int = -1):
+        if z.ndim == 2:
+            z = deepcopy(z.reshape((-1, )))
+
+        self.dt = dt
+        self.ndim = ndim
+        self.cov_update_policy: CovariancePolicy = cov_update_policy(ndim, z.size)
+        # Create Kalman filter model matrices.
+        self._motion_mat = np.eye(ndim, ndim)
+        for i in range(4 - (ndim % 2)):
+            self._motion_mat[i, i + 4] = dt
+
+        self._update_mat = np.eye(4, ndim)
+
+        self.x = np.zeros((ndim,))
+        self.x[:4] = z[:]
+
+        self.covariance = self.cov_update_policy.get_init_state_cov(z)
+        self.id = id
+
+    def predict(self, mean: Optional[np.ndarray] = None,
+                covariance: Optional[np.ndarray] = None):
+        """Run Kalman filter prediction step.
+
+        Parameters
+        ----------
+        mean : ndarray
+            The 8 dimensional mean vector of the object state at the previous
+            time step.
+        covariance : ndarray
+            The 8x8 dimensional covariance matrix of the object state at the
+            previous time step.
+
+        Returns
+        -------
+        (ndarray, ndarray)
+            Returns the mean vector and covariance matrix of the predicted
+            state. Unobserved velocities are initialized to 0 mean.
+
+        """
+        update = False
+        if mean is None:
+            mean = self.x
+            covariance = self.covariance
+            update = True
+        motion_cov = self.cov_update_policy.get_Q(mean)
+
+        mean = np.dot(self._motion_mat, mean)
+        covariance = np.linalg.multi_dot((
+            self._motion_mat, covariance, self._motion_mat.T)) + motion_cov
+
+        if update:
+            self.x = mean
+            self.covariance = covariance
+
+        return mean, covariance
+
+    def project(self, confidence=.0):
+        """Project state distribution to measurement space.
+
+        Returns
+        -------
+        (ndarray, ndarray)
+            Returns the projected mean and covariance matrix of the given state
+            estimate.
+
+        """
+
+        innovation_cov = self.cov_update_policy.get_R(self.x, 0)
+
+        mean = np.dot(self._update_mat, self.x)
+        covariance = np.linalg.multi_dot((
+            self._update_mat, self.covariance, self._update_mat.T))
+        return mean, covariance + innovation_cov
+
+    def update(self, z: np.ndarray, confidence=.0):
+        """Run Kalman filter correction step.
+
+        Returns
+        -------
+        (ndarray, ndarray)
+            Returns the measurement-corrected state distribution.
+
+        """
+
+        if z.ndim == 2:
+            z = deepcopy(z.reshape((-1, )))
+        projected_mean, projected_cov = self.project(confidence)
+
+        chol_factor, lower = scipy.linalg.cho_factor(
+            projected_cov, lower=True, check_finite=False)
+        kalman_gain = scipy.linalg.cho_solve(
+            (chol_factor, lower), np.dot(self.covariance, self._update_mat.T).T,
+            check_finite=False).T
+
+        innovation = z - projected_mean
+
+        self.x = self.x + np.dot(innovation, kalman_gain.T)
+        self.covariance = self.covariance - np.linalg.multi_dot((
+            kalman_gain, projected_cov, kalman_gain.T))
+
+        return self.x, self.covariance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,12 @@
 from boxmot import (
-    StrongSort, BotSort, DeepOcSort, OcSort, ByteTrack, ImprAssocTrack, get_tracker_config, create_tracker,
+    StrongSort, BotSort, DeepOcSort, OcSort, ByteTrack, ImprAssocTrack, BoostTrack, get_tracker_config, create_tracker,
 )
 
-MOTION_N_APPEARANCE_TRACKING_NAMES = ['botsort', 'deepocsort', 'strongsort', 'imprassoc']
+MOTION_N_APPEARANCE_TRACKING_NAMES = ['botsort', 'deepocsort', 'strongsort', 'imprassoc', 'boosttrack']
 MOTION_ONLY_TRACKING_NAMES = ['ocsort', 'bytetrack']
 
-MOTION_N_APPEARANCE_TRACKING_METHODS=[StrongSort, BotSort, DeepOcSort, ImprAssocTrack]
+MOTION_N_APPEARANCE_TRACKING_METHODS=[StrongSort, BotSort, DeepOcSort, ImprAssocTrack, BoostTrack]
 MOTION_ONLY_TRACKING_METHODS=[OcSort, ByteTrack]
 
-ALL_TRACKERS = ['botsort', 'deepocsort', 'ocsort', 'bytetrack', 'strongsort', 'imprassoc']
+ALL_TRACKERS = ['botsort', 'deepocsort', 'ocsort', 'bytetrack', 'strongsort', 'imprassoc', 'boosttrack']
 PER_CLASS_TRACKERS = ['botsort', 'deepocsort', 'ocsort', 'bytetrack', 'imprassoc']

--- a/tests/unit/test_trackers.py
+++ b/tests/unit/test_trackers.py
@@ -41,7 +41,7 @@ def test_tracker_output_size(tracker_type):
     )
 
     rgb = np.random.randint(255, size=(640, 640, 3), dtype=np.uint8)
-    det = np.array([[144, 212, 578, 480, 0.82, 0],
+    det = np.array([[144, 212, 400, 480, 0.82, 0],
                     [425, 281, 576, 472, 0.72, 65]])
 
     output = tracker.update(det, rgb)

--- a/tracking/detectors/yolox.py
+++ b/tracking/detectors/yolox.py
@@ -75,7 +75,7 @@ class YoloXStrategy(YoloInterface):
             # needed for bytetrack yolox people models
             # update with your custom model needs
             exp.num_classes = 1
-        elif model.stem == model_type:
+        elif model.stem.startswith(model_type):
             exp.num_classes = 1
 
         ckpt = torch.load(

--- a/tracking/track.py
+++ b/tracking/track.py
@@ -130,7 +130,7 @@ def parse_opt():
     parser.add_argument('--reid-model', type=Path, default=WEIGHTS / 'osnet_x0_25_msmt17.pt',
                         help='reid model path')
     parser.add_argument('--tracking-method', type=str, default='deepocsort',
-                        help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc')
+                        help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc, boosttrack')
     parser.add_argument('--source', type=str, default='0',
                         help='file/dir/URL/glob, 0 for webcam')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=None,

--- a/tracking/utils.py
+++ b/tracking/utils.py
@@ -153,6 +153,7 @@ def download_mot_dataset(val_tools_path, benchmark, max_retries=5, backoff_facto
 
     retries = 0  # Initialize retry counter
 
+    response = None
     while retries <= max_retries:
         try:
             response = requests.head(url, allow_redirects=True)
@@ -201,7 +202,7 @@ def download_mot_dataset(val_tools_path, benchmark, max_retries=5, backoff_facto
                 return None
 
         except (requests.HTTPError, requests.ConnectionError) as e:
-            if response.status_code == 416:  # Handle "Requested Range Not Satisfiable" error
+            if response and response.status_code == 416:  # Handle "Requested Range Not Satisfiable" error
                 LOGGER.info(f"{benchmark}.zip is already fully downloaded.")
                 return zip_dst
             LOGGER.error(f'Error occurred while downloading {benchmark}.zip: {e}')

--- a/tracking/utils.py
+++ b/tracking/utils.py
@@ -336,7 +336,7 @@ def convert_to_mot_format(results: Union[Results, np.ndarray], frame_idx: int) -
             mot_results = np.column_stack((
                 frame_idx_column, # frame index
                 results[:, 4].astype(np.int32),  # track id
-                tlwh.astype(np.int32),  # top,left,width,height
+                tlwh.round().astype(np.int32),  # top,left,width,height
                 np.ones((results.shape[0], 1), dtype=np.int32),  # "not ignored"
                 results[:, 6].astype(np.int32),  # class
                 results[:, 5],  # confidence (float)

--- a/tracking/val.py
+++ b/tracking/val.py
@@ -503,8 +503,10 @@ if __name__ == "__main__":
     
     # download MOT benchmark
     download_mot_eval_tools(opt.val_tools_path)
-    zip_path = download_mot_dataset(opt.val_tools_path, opt.benchmark)
-    unzip_mot_dataset(zip_path, opt.val_tools_path, opt.benchmark)
+
+    if not Path(opt.source).exists():
+        zip_path = download_mot_dataset(opt.val_tools_path, opt.benchmark)
+        unzip_mot_dataset(zip_path, opt.val_tools_path, opt.benchmark)
 
     if opt.benchmark == 'MOT17':
         cleanup_mot17(opt.source)

--- a/tracking/val.py
+++ b/tracking/val.py
@@ -459,7 +459,7 @@ def parse_opt() -> argparse.Namespace:
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--vid-stride', type=int, default=1, help='video frame-rate stride')
     parser.add_argument('--ci', action='store_true', help='Automatically reuse existing due to no UI in CI')
-    parser.add_argument('--tracking-method', type=str, default='deepocsort', help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc')
+    parser.add_argument('--tracking-method', type=str, default='deepocsort', help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc, boosttrack')
     parser.add_argument('--dets-file-path', type=Path, help='path to detections file')
     parser.add_argument('--embs-file-path', type=Path, help='path to embeddings file')
     parser.add_argument('--exp-folder-path', type=Path, help='path to experiment folder')
@@ -484,7 +484,7 @@ def parse_opt() -> argparse.Namespace:
     generate_mot_results_parser = subparsers.add_parser('generate_mot_results', help='Generate MOT results')
     generate_mot_results_parser.add_argument('--yolo-model', nargs='+', type=Path, default=WEIGHTS / 'yolov8n.pt', help='yolo model path')
     generate_mot_results_parser.add_argument('--reid-model', nargs='+', type=Path, default=WEIGHTS / 'osnet_x0_25_msmt17.pt', help='reid model path')
-    generate_mot_results_parser.add_argument('--tracking-method', type=str, default='deepocsort', help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc')
+    generate_mot_results_parser.add_argument('--tracking-method', type=str, default='deepocsort', help='deepocsort, botsort, strongsort, ocsort, bytetrack, imprassoc, boosttrack')
     generate_mot_results_parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
 
     # Subparser for trackeval

--- a/tracking/val.py
+++ b/tracking/val.py
@@ -300,7 +300,7 @@ def parse_mot_results(results: str) -> dict:
         dict: A dictionary containing HOTA, MOTA, and IDF1 scores.
     """
     combined_results = results.split('COMBINED')[2:-1]
-    combined_results = [float(re.findall("[-+]?(?:\d*\.*\d+)", f)[0])
+    combined_results = [float(re.findall(r"[-+]?(?:\d*\.*\d+)", f)[0])
                         for f in combined_results]
 
     results_dict = {}
@@ -362,7 +362,7 @@ def run_generate_dets_embs(opt: argparse.Namespace) -> None:
     Args:
         opt (Namespace): Parsed command line arguments.
     """
-    mot_folder_paths = [item for item in Path(opt.source).iterdir()]
+    mot_folder_paths = sorted([item for item in Path(opt.source).iterdir()])
     for y in opt.yolo_model:
         for i, mot_folder_path in enumerate(mot_folder_paths):
             dets_path = Path(opt.project) / 'dets_n_embs' / y.stem / 'dets' / (mot_folder_path.name + '.txt')
@@ -391,12 +391,12 @@ def run_generate_mot_results(opt: argparse.Namespace, evolve_config: dict = None
         opt.exp_folder_path = exp_folder_path
 
         mot_folder_names = [item.stem for item in Path(opt.source).iterdir()]
-        dets_file_paths = [item for item in (opt.project / "dets_n_embs" / y.stem / 'dets').glob('*.txt')
+        dets_file_paths = sorted([item for item in (opt.project / "dets_n_embs" / y.stem / 'dets').glob('*.txt')
                            if not item.name.startswith('.')
-                           and item.stem in mot_folder_names]
-        embs_file_paths = [item for item in (opt.project / "dets_n_embs" / y.stem / 'embs' / opt.reid_model[0].stem).glob('*.txt')
+                           and item.stem in mot_folder_names])
+        embs_file_paths = sorted([item for item in (opt.project / "dets_n_embs" / y.stem / 'embs' / opt.reid_model[0].stem).glob('*.txt')
                            if not item.name.startswith('.')
-                           and item.stem in mot_folder_names]
+                           and item.stem in mot_folder_names])
 
         for d, e in zip(dets_file_paths, embs_file_paths):
             mot_result_path = exp_folder_path / (d.stem + '.txt')


### PR DESCRIPTION
Hello! I've decided to add BoostTrack to boxmot, because I am currently researching this tracker results and can't wait for someone else to do it :smiley: 

There are many comments, and I could forget something important:


###  1. Reproduce BoostTrack tracker results

Originally, after running BoostTrack scripts from original repository with `val_half.json`, i got:

```
{"HOTA": 68.486, "MOTA": 75.508, "IDF1": 81.277}
```

To reproduce these results in boxmot:

1)  Download [val_half](https://drive.google.com/file/d/1QZXuLZq6zp4_DrOB0kCwYkclNEksFBEh/view?usp=drive_link) from my drive or prepare it by yourself (It contains already splitted MOT17 validation part). Folder path should be `val_utils/data/MOT17/val_half`
2) Download ByteTrack ablation model from [here](https://drive.google.com/file/d/1iqhM-6V_r1FpOlOzrdP_Ejshgk0DxOob/view), move it to boxmot folder and rename it to `yolox_x_ablation.pth`
2) run command:

```
python3 tracking/val.py --yolo-model yolox_x_ablation.pth --reid-model osnet_x1_0_msmt17.pt --tracking-method boosttrack --verbose --source ./tracking/val_utils/data/MOT17/val_half/ --conf 0.1
```

Results should be:

```
{"HOTA": 68.382, "MOTA": 75.558, "IDF1": 81.154}`
```

For closest results you need to add these lines to [val.py](https://github.com/mikel-brostrom/boxmot/blob/dbce5f2bc4eaecbdce702c600ed0cc04fbe6e43b/tracking/val.py#L277) (between `embs = frame_dets_n_embs[:, 7:]` and `tracker.update`):

```
if args.tracking_method == "boosttrack":
            with open(source.parent / "seqinfo.ini") as f: 
                seq_data = f.readlines()

            x = next(sd for sd in seq_data if sd.startswith("frameRate"))
            frame_rate = int(x[x.find("=") + 1:x.find('\n')])

            tracker.max_age = max(30, frame_rate * 2)
```

Idea: authors of boosttrack added [dynamic](https://github.com/vukasin-stanojevic/BoostTrack/blob/8e80cd263ec33144db91c356d194bfcdaa9894bf/default_settings.py#L64) `max_age` a.k.a. `max_time_lost` to their tracker, which uses `max(30, frame_rate * 2)` of each MOT17, MOT20 sequence.

After this change results should be:

```
{"HOTA": 68.517, "MOTA": 75.55, "IDF1": 81.398}
```

I could also reproduce the original result one to one, but it requires too many steps to show it here. The most important thing is that the tracker works exactly the same as the original, the only difference here is in the processing of detections, which is a bit different in boxmot and boosttrack original repo.

### 2. Comparison: BoostTrack vs ByteTrack

In my experience, this tracker shows speed like 70-75 FPS, while bytetrack works on 200 FPS. Main problem is of course in ECC. I turned it off to check:

BoostTrack without ecc: `{"HOTA": 67.42, "MOTA": 75.01, "IDF1": 79.34}`, and FPS is almost equal to ByteTrack
ByteTrack: `{"HOTA": 67.619, "MOTA": 78.081, "IDF1": 79.188}`.

So my verdict is that default BoostTrack is essentially the same or even worse than ByteTrack.

### 3. BoostTrack+ and BoostTrack++

1) BoostTrack+  == BoostTrack with ReID. Currently I didn't check this tracker with ReID, I will do it in next iteration.

2) Of course, main contribution of this tracker is BoostTrack++ version, but currently I don't know how to better add both + and ++ to boxmot. There are only few changes in configs, and now there is no functionality in boxmot to add tracker without changing its class while changing only its config file. This thing should be discussed and maybe you have your own opinion.

#1826 