### PR TITLE
Detections and embeddings (Updated and fixed) 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11']
-        tracker: ["ocsort", "bytetrack", "botsort", "hybridsort", "deepocsort", "imprassoc", "strongsort", "boosttrack"]
+        tracker: ["ocsort", "bytetrack", "botsort", "deepocsort", "imprassoc", "strongsort", "boosttrack"]
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     outputs:
       status: ${{ job.status }}
     env:
-      TRACKERS: "ocsort bytetrack botsort hybridsort deepocsort imprassoc strongsort boosttrack"
+      TRACKERS: "ocsort bytetrack botsort deepocsort imprassoc strongsort boosttrack"
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 50

--- a/boxmot/appearance/backends/base_backend.py
+++ b/boxmot/appearance/backends/base_backend.py
@@ -48,8 +48,8 @@ class BaseModelBackend:
                             dtype=torch.half if self.half else torch.float, device=self.device)
         
         for i, box in enumerate(xyxys):
-            x1, y1, x2, y2 = box.astype('int')
-            x1, y1, x2, y2 = max(0, x1), max(0, y1), min(w - 1, x2), min(h - 1, y2)
+            x1, y1, x2, y2 = box.round().astype('int')
+            x1, y1, x2, y2 = max(0, x1), max(0, y1), min(w, x2), min(h, y2)
             crop = img[y1:y2, x1:x2]
             
             # Resize and convert color in one step

--- a/boxmot/configs/bytetrack.yaml
+++ b/boxmot/configs/bytetrack.yaml
@@ -1,3 +1,8 @@
+min_thresh:
+  type: uniform
+  default: 0.2  # from the default parameters
+  range: [0.1, 0.3]
+
 track_thresh:
   type: uniform
   default: 0.6  # from the default parameters

--- a/boxmot/trackers/boosttrack/boosttrack.py
+++ b/boxmot/trackers/boosttrack/boosttrack.py
@@ -208,6 +208,7 @@ class BoostTrack:
         if self.use_duo_boost:
             dets = self.duo_confidence_boost(dets)
 
+        dets_embs = np.ones((dets.shape[0], 1))
         if dets.size > 0:
             remain_inds = dets[:, 4] >= self.det_thresh
             dets = dets[remain_inds]
@@ -220,10 +221,8 @@ class BoostTrack:
                     dets_embs = self.reid_model.get_features(dets[:, :4], img)
         else:
             scores = np.empty(0)
-            dets_embs = np.ones((dets.shape[0], 1))
-            
 
-        if self.with_reid and len(self.trackers) > 0:
+        if self.with_reid and len(self.trackers) > 0 and len(dets_embs) > 0:
             tracker_embs = np.array([trk.get_emb() for trk in self.trackers])
             emb_cost = dets_embs.reshape(dets_embs.shape[0], -1) @ tracker_embs.reshape((tracker_embs.shape[0], -1)).T
         else:

--- a/boxmot/trackers/bytetrack/bytetrack.py
+++ b/boxmot/trackers/bytetrack/bytetrack.py
@@ -120,6 +120,7 @@ class ByteTrack(BaseTracker):
     BYTETracker: A tracking algorithm based on ByteTrack, which utilizes motion-based tracking.
 
     Args:
+        min_thresh (float, optional): Threshold for detection confidence. Detections below this threshold are discarded.
         track_thresh (float, optional): Threshold for detection confidence. Detections above this threshold are considered for tracking in the first association round.
         match_thresh (float, optional): Threshold for the matching step in data association. Controls the maximum distance allowed between tracklets and detections for a match.
         track_buffer (int, optional): Number of frames to keep a track alive after it was last detected. A longer buffer allows for more robust tracking but may increase identity switches.
@@ -128,6 +129,7 @@ class ByteTrack(BaseTracker):
     """
     def __init__(
         self,
+        min_thresh: float = 0.1,
         track_thresh: float = 0.45,
         match_thresh: float = 0.8,
         track_buffer: int = 25,
@@ -143,6 +145,7 @@ class ByteTrack(BaseTracker):
         self.track_buffer = track_buffer
 
         self.per_class = per_class
+        self.min_thresh = min_thresh
         self.track_thresh = track_thresh
         self.match_thresh = match_thresh
         self.det_thresh = track_thresh

--- a/tracking/detectors/yolox.py
+++ b/tracking/detectors/yolox.py
@@ -20,6 +20,7 @@ YOLOX_ZOO = {
     'yolox_m.pt': 'https://drive.google.com/uc?id=11Zb0NN_Uu7JwUd9e6Nk8o2_EUfxWqsun',
     'yolox_l.pt': 'https://drive.google.com/uc?id=1XwfUuCBF4IgWBWK2H7oOhQgEj9Mrb3rz',
     'yolox_x.pt': 'https://drive.google.com/uc?id=1P4mY0Yyd3PPTybgZkjMYhFri88nTmJX5',
+    'yolox_x_ablation.pt': 'https://drive.google.com/uc?id=1iqhM-6V_r1FpOlOzrdP_Ejshgk0DxOob',
 }
 
 
@@ -65,10 +66,11 @@ class YoloXStrategy(YoloInterface):
         LOGGER.info(f'Loading {model_type} with {str(model)}')
 
         # download crowdhuman bytetrack models
-        if not model.exists() and model.stem == model_type:
+        if not model.exists() and (model.stem == model_type or
+                                   model.stem == 'yolox_x_ablation'):
             LOGGER.info('Downloading pretrained weights...')
             gdown.download(
-                url=YOLOX_ZOO[model_type + '.pt'],
+                url=YOLOX_ZOO[model.stem + '.pt'],
                 output=str(model),
                 quiet=False
             )

--- a/tracking/val.py
+++ b/tracking/val.py
@@ -449,7 +449,7 @@ def parse_opt() -> argparse.Namespace:
     parser.add_argument('--reid-model', nargs='+', type=Path, default=[WEIGHTS / 'osnet_x0_25_msmt17.pt'], help='reid model path')
     parser.add_argument('--source', type=str, help='file/dir/URL/glob, 0 for webcam')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=None, help='inference size h,w')
-    parser.add_argument('--conf', type=float, default=0.5, help='confidence threshold')
+    parser.add_argument('--conf', type=float, default=0.01, help='min confidence threshold')
     parser.add_argument('--iou', type=float, default=0.7, help='intersection over union (IoU) threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--classes', nargs='+', type=int, default=0, help='filter by class: --classes 0, or --classes 0 2 3')


### PR DESCRIPTION
1) Added fix for embedding extraction: correct rounding of coordinates to closest integer and clipping without unneeded subtraction
2) Added `min_thresh` hyperparam especially for ByteTrack.
3) Bug fixes for BoostTrack
4) Removed unneded dets assignment and added correct boxes filter
5) YOLOX Ablation
6) Changed `--conf` value to `0.01`. With `0.0` there are too many detections and there is OOM in embedding extraction. I think, `0.01` is small enough value

Here are new [runs.zip](https://drive.google.com/file/d/1LOFbrccksJAu_mWjh-AIFxuQqJJHrAHI/view?usp=drive_link) generated after all these fixes with command (for bytetrack as example):

```
python3 tracking/val.py --classes 0 --yolo-model yolox_x_ablation.pth --reid-model osnet_x1_0_dukemtmcreid.pt --t
racking-method bytetrack --verbose --source ./tracking/val_utils/data/MOT17-50/train
```

Outputs should be:

```
{"HOTA": 67.619, "MOTA": 78.081, "IDF1": 79.188}
```