### PR TITLE
Added min confidence threshold to existing trackers

### DIFF
--- a/boxmot/configs/bytetrack.yaml
+++ b/boxmot/configs/bytetrack.yaml
@@ -1,6 +1,6 @@
-min_thresh:
+min_conf:
   type: uniform
-  default: 0.2  # from the default parameters
+  default: 0.1  # from the default parameters
   range: [0.1, 0.3]
 
 track_thresh:

--- a/boxmot/configs/ocsort.yaml
+++ b/boxmot/configs/ocsort.yaml
@@ -1,3 +1,8 @@
+min_conf:
+  type: uniform
+  default: 0.1  # from the default parameters
+  range: [0.1, 0.3]
+
 det_thresh:
   type: uniform
   default: 0.6  # from the default parameters

--- a/boxmot/configs/strongsort.yaml
+++ b/boxmot/configs/strongsort.yaml
@@ -1,3 +1,8 @@
+min_conf:
+  type: uniform
+  default: 0.6  # from the default parameters
+  range: [0.2, 0.8]
+
 ema_alpha:
   type: uniform
   default: 0.9  # from the default parameters

--- a/boxmot/trackers/bytetrack/bytetrack.py
+++ b/boxmot/trackers/bytetrack/bytetrack.py
@@ -120,7 +120,7 @@ class ByteTrack(BaseTracker):
     BYTETracker: A tracking algorithm based on ByteTrack, which utilizes motion-based tracking.
 
     Args:
-        min_thresh (float, optional): Threshold for detection confidence. Detections below this threshold are discarded.
+        min_conf (float, optional): Threshold for detection confidence. Detections below this threshold are discarded.
         track_thresh (float, optional): Threshold for detection confidence. Detections above this threshold are considered for tracking in the first association round.
         match_thresh (float, optional): Threshold for the matching step in data association. Controls the maximum distance allowed between tracklets and detections for a match.
         track_buffer (int, optional): Number of frames to keep a track alive after it was last detected. A longer buffer allows for more robust tracking but may increase identity switches.
@@ -129,7 +129,7 @@ class ByteTrack(BaseTracker):
     """
     def __init__(
         self,
-        min_thresh: float = 0.1,
+        min_conf: float = 0.1,
         track_thresh: float = 0.45,
         match_thresh: float = 0.8,
         track_buffer: int = 25,
@@ -145,7 +145,7 @@ class ByteTrack(BaseTracker):
         self.track_buffer = track_buffer
 
         self.per_class = per_class
-        self.min_thresh = min_thresh
+        self.min_conf = min_conf
         self.track_thresh = track_thresh
         self.match_thresh = match_thresh
         self.det_thresh = track_thresh
@@ -169,7 +169,7 @@ class ByteTrack(BaseTracker):
 
         remain_inds = confs > self.track_thresh
 
-        inds_low = confs > 0.1
+        inds_low = confs > self.min_conf
         inds_high = confs < self.track_thresh
         inds_second = np.logical_and(inds_low, inds_high)
 

--- a/boxmot/trackers/deepocsort/deepocsort.py
+++ b/boxmot/trackers/deepocsort/deepocsort.py
@@ -326,7 +326,7 @@ class DeepOcSort(BaseTracker):
         if self.embedding_off or dets.shape[0] == 0:
             dets_embs = np.ones((dets.shape[0], 1))
         elif embs is not None:
-            dets_embs = embs
+            dets_embs = embs[remain_inds]
         else:
             # (Ndets x X) [512, 1024, 2048]
             dets_embs = self.model.get_features(dets[:, 0:4], img)

--- a/boxmot/trackers/ocsort/ocsort.py
+++ b/boxmot/trackers/ocsort/ocsort.py
@@ -203,6 +203,7 @@ class OcSort(BaseTracker):
     def __init__(
         self,
         per_class: bool = False,
+        min_conf: float = 0.1,
         det_thresh: float = 0.2,
         max_age: int = 30,
         min_hits: int = 3,
@@ -219,6 +220,7 @@ class OcSort(BaseTracker):
         Sets key parameters for SORT
         """
         self.per_class = per_class
+        self.min_conf = min_conf
         self.max_age = max_age
         self.min_hits = min_hits
         self.asso_threshold = asso_threshold
@@ -251,7 +253,7 @@ class OcSort(BaseTracker):
         dets = np.hstack([dets, np.arange(len(dets)).reshape(-1, 1)])
         confs = dets[:, 4+self.is_obb] 
 
-        inds_low = confs > 0.1
+        inds_low = confs > self.min_conf
         inds_high = confs < self.det_thresh
         inds_second = np.logical_and(
             inds_low, inds_high


### PR DESCRIPTION
Hello! I've added some fixes to existing trackers according to new detections with conf >= 0.01

1) BotSort - already has this hyperparam, HOTA: 68.504 -> 68.251 (-0.3)
2) ByteTrack - added min_conf instead of existing 0.1 const. HOTA: 66.536 -> 67.619 (+1.1)
3) DeepOcSort - added small bug fix (idk how did it work before). HOTA: 62.913 -> 67.348 (+4.4)
4) HybridSort - didn't change, because it is still broken
5) ImprAssOc - already has min_conf, HOTA 64.096 -> 63.699 (-0.4). With changing this min_conf to higher values, tracker has better results, but I didnt change their default parameter
6) OcSort - added min_conf instead of existing 0.1 const. HOTA: 65.187 -> 66.441 (+1.3)
7) StrongSort - didn't have any threshold, I've added one which gives best results. HOTA: 68.329 -> 67.394 (-1)

Results are a bit strange at the first glance, but are much more correct according to [papers with code benchmark](https://paperswithcode.com/sota/multi-object-tracking-on-mot17). For example, in this table OcSort < StrongSort < DeepOcSort, and our results now look better. Botsort and Boosttrack are the best, the same as in table.