### PR TITLE
Fix dimension length typo in basetracker

### DIFF
--- a/boxmot/trackers/basetracker.py
+++ b/boxmot/trackers/basetracker.py
@@ -219,7 +219,7 @@ class BaseTracker(ABC):
         if self.is_obb:
             assert (
                 dets.shape[1] == 7
-            ), "Unsupported 'dets' 2nd dimension length, valid lengths is 6 (cx,cy,w,h,angle,conf,cls)"
+            ), "Unsupported 'dets' 2nd dimension length, valid length is 7 (cx,cy,w,h,angle,conf,cls)"
         else:
             assert (
                 dets.shape[1] == 6

--- a/boxmot/trackers/basetracker.py
+++ b/boxmot/trackers/basetracker.py
@@ -219,11 +219,11 @@ class BaseTracker(ABC):
         if self.is_obb:
             assert (
                 dets.shape[1] == 7
-            ), "Unsupported 'dets' 2nd dimension lenght, valid lenghts is 6 (cx,cy,w,h,angle,conf,cls)"
+            ), "Unsupported 'dets' 2nd dimension length, valid lengths is 6 (cx,cy,w,h,angle,conf,cls)"
         else:
             assert (
                 dets.shape[1] == 6
-            ), "Unsupported 'dets' 2nd dimension lenght, valid lenghts is 6 (x1,y1,x2,y2,conf,cls)"
+            ), "Unsupported 'dets' 2nd dimension length, valid lengths is 6 (x1,y1,x2,y2,conf,cls)"
 
     def id_to_color(self, id: int, saturation: float = 0.75, value: float = 0.95) -> tuple:
         """


### PR DESCRIPTION
## Summary
- fix "lenght" typo in BaseTracker dimension assertion messages

## Testing
- `pre-commit run --files boxmot/trackers/basetracker.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890d509740c832da2a50013a8d2db8c