### PR TITLE
Remove unused association helper

### DIFF
--- a/boxmot/utils/association.py
+++ b/boxmot/utils/association.py
@@ -30,52 +30,6 @@ def linear_assignment(cost_matrix):
         return np.array([list(zip(x, y))])
 
 
-def associate_detections_to_trackers(detections, trackers, iou_threshold=0.3):
-    """
-    Assigns detections to tracked object (both represented as bounding boxes)
-    Returns 3 lists of matches, unmatched_detections and unmatched_trackers
-    """
-    if len(trackers) == 0:
-        return (
-            np.empty((0, 2), dtype=int),
-            np.arange(len(detections)),
-            np.empty((0, 5), dtype=int),
-        )
-
-    iou_matrix = AssociationFunction.iou_batch(detections, trackers)
-
-    if min(iou_matrix.shape) > 0:
-        a = (iou_matrix > iou_threshold).astype(np.int32)
-        if a.sum(1).max() == 1 and a.sum(0).max() == 1:
-            matched_indices = np.stack(np.where(a), axis=1)
-        else:
-            matched_indices = linear_assignment(-iou_matrix)
-    else:
-        matched_indices = np.empty(shape=(0, 2))
-
-    unmatched_detections = []
-    for d, det in enumerate(detections):
-        if d not in matched_indices[:, 0]:
-            unmatched_detections.append(d)
-    unmatched_trackers = []
-    for t, trk in enumerate(trackers):
-        if t not in matched_indices[:, 1]:
-            unmatched_trackers.append(t)
-
-    # filter out matched with low IOU
-    matches = []
-    for m in matched_indices:
-        if iou_matrix[m[0], m[1]] < iou_threshold:
-            unmatched_detections.append(m[0])
-            unmatched_trackers.append(m[1])
-        else:
-            matches.append(m.reshape(1, 2))
-    if len(matches) == 0:
-        matches = np.empty((0, 2), dtype=int)
-    else:
-        matches = np.concatenate(matches, axis=0)
-
-    return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
 
 
 def compute_aw_max_metric(emb_cost, w_association_emb, bottom=0.5):


### PR DESCRIPTION
## Summary
- drop unused `associate_detections_to_trackers` helper from association utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8 boxmot/utils/association.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890da69101c832d8c5bbc4212c00f14