### PR TITLE
Eliminate runtime warnings in detectors and trackers

### DIFF
--- a/boxmot/engine/detectors/rfdetr.py
+++ b/boxmot/engine/detectors/rfdetr.py
@@ -45,10 +45,9 @@ class RFDETRStrategy(YoloInterface):
         This function saves image paths for the current batch,
         being passed as callback on_predict_batch_start
         """
-        assert (
-            isinstance(predictor, DetectionPredictor),
-            "Only ultralytics predictors are supported",
-        )
+        assert isinstance(
+            predictor, DetectionPredictor
+        ), "Only ultralytics predictors are supported"
         self.im_paths = predictor.batch[0]
 
     def preprocess(self, im) -> torch.Tensor:

--- a/boxmot/engine/detectors/yolox.py
+++ b/boxmot/engine/detectors/yolox.py
@@ -186,10 +186,9 @@ class YoloXStrategy(YoloInterface):
         This function saves image paths for the current batch,
         being passed as callback on_predict_batch_start
         """
-        assert (
-            isinstance(predictor, DetectionPredictor),
-            "Only ultralytics predictors are supported",
-        )
+        assert isinstance(
+            predictor, DetectionPredictor
+        ), "Only ultralytics predictors are supported"
         self.im_paths = predictor.batch[0]
 
     # This preprocess differs from the current version of YOLOX preprocess, but ByteTrack uses it

--- a/boxmot/motion/kalman_filters/obb/xywha_kf.py
+++ b/boxmot/motion/kalman_filters/obb/xywha_kf.py
@@ -120,9 +120,7 @@ class KalmanBoxTrackerOBB(object):
                         break
                 if previous_box is None:
                     previous_box = self.last_observation
-                """
-                  Estimate the track speed direction with observations \Delta t steps away
-                """
+                # Estimate the track speed direction with observations Δt steps away
                 self.velocity = speed_direction_obb(previous_box, bbox)
 
             """

--- a/boxmot/trackers/deepocsort/deepocsort.py
+++ b/boxmot/trackers/deepocsort/deepocsort.py
@@ -160,9 +160,7 @@ class KalmanBoxTracker:
                         break
                 if previous_box is None:
                     previous_box = self.last_observation
-                """
-                  Estimate the track speed direction with observations \Delta t steps away
-                """
+                # Estimate the track speed direction with observations Δt steps away
                 self.velocity = speed_direction(previous_box, bbox)
             """
               Insert new observations. This is a ugly way to maintain both self.observations

--- a/boxmot/trackers/ocsort/ocsort.py
+++ b/boxmot/trackers/ocsort/ocsort.py
@@ -150,9 +150,7 @@ class KalmanBoxTracker(object):
                         break
                 if previous_box is None:
                     previous_box = self.last_observation
-                """
-                  Estimate the track speed direction with observations \Delta t steps away
-                """
+                # Estimate the track speed direction with observations Δt steps away
                 self.velocity = speed_direction(previous_box, bbox)
 
             """


### PR DESCRIPTION
## Summary
- fix asserts in YOLOX and RFDETR detectors so they validate predictor objects correctly
- replace stray triple-quoted strings with comments in tracker/Kalman code to avoid invalid escape sequence warnings

## Testing
- `python -Werror -m py_compile boxmot/engine/detectors/rfdetr.py boxmot/engine/detectors/yolox.py boxmot/motion/kalman_filters/obb/xywha_kf.py boxmot/trackers/deepocsort/deepocsort.py boxmot/trackers/ocsort/ocsort.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install numpy -q` *(fails: 403 Client Error: Forbidden for url: https://pypi.org/simple/numpy/)*
- `pip install pre-commit -q` *(fails: 403 Client Error: Forbidden for url: https://pypi.org/simple/pre-commit/)*

------
https://chatgpt.com/codex/tasks/task_e_6890e08557a0832dae5ae26828b779cc