### PR TITLE
Reset detection index for unmatched tracks

### DIFF
--- a/boxmot/trackers/boosttrack/boosttrack.py
+++ b/boxmot/trackers/boosttrack/boosttrack.py
@@ -108,6 +108,7 @@ class KalmanBoxTracker:
         if self.time_since_update > 0:
             self.hit_streak = 0
         self.time_since_update += 1
+        self.det_ind = -1
         return self.get_state()
 
     def get_state(self):
@@ -321,11 +322,13 @@ class BoostTrack(BaseTracker):
         self.active_tracks = []
         for trk in self.trackers:
             d = trk.get_state()[0]
-            if (trk.time_since_update < 1) and (
-                trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits
-            ):
+            if trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits:
                 # Format: [x1, y1, x2, y2, id, confidence, cls, det_ind]
-                outputs.append(np.array([d[0], d[1], d[2], d[3], trk.id, trk.conf, trk.cls, trk.det_ind]))
+                outputs.append(
+                    np.array(
+                        [d[0], d[1], d[2], d[3], trk.id, trk.conf, trk.cls, trk.det_ind]
+                    )
+                )
                 self.active_tracks.append(trk)
             
         self.trackers = [trk for trk in self.trackers if trk.time_since_update <= self.max_age]

--- a/boxmot/trackers/botsort/basetrack.py
+++ b/boxmot/trackers/botsort/basetrack.py
@@ -118,18 +118,24 @@ class BaseTrack:
         Marks the track as lost.
         """
         self.state = TrackState.Lost
+        if hasattr(self, "det_ind"):
+            self.det_ind = -1
 
     def mark_long_lost(self):
         """
         Marks the track as long lost.
         """
         self.state = TrackState.LongLost
+        if hasattr(self, "det_ind"):
+            self.det_ind = -1
 
     def mark_removed(self):
         """
         Marks the track as removed.
         """
         self.state = TrackState.Removed
+        if hasattr(self, "det_ind"):
+            self.det_ind = -1
 
     @staticmethod
     def clear_count():

--- a/boxmot/trackers/bytetrack/basetrack.py
+++ b/boxmot/trackers/bytetrack/basetrack.py
@@ -50,9 +50,13 @@ class BaseTrack(object):
 
     def mark_lost(self):
         self.state = TrackState.Lost
+        if hasattr(self, "det_ind"):
+            self.det_ind = -1
 
     def mark_removed(self):
         self.state = TrackState.Removed
+        if hasattr(self, "det_ind"):
+            self.det_ind = -1
 
     @staticmethod
     def clear_count():

--- a/boxmot/trackers/deepocsort/deepocsort.py
+++ b/boxmot/trackers/deepocsort/deepocsort.py
@@ -176,6 +176,7 @@ class KalmanBoxTracker:
 
             self.kf.update(self.bbox_to_z_func(bbox))
         else:
+            self.det_ind = -1
             self.kf.update(det)
             self.frozen = True
 
@@ -478,9 +479,7 @@ class DeepOcSort(BaseTracker):
                 we didn't notice significant difference here
                 """
                 d = trk.last_observation[:4]
-            if (trk.time_since_update < 1) and (
-                trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits
-            ):
+            if trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits:
                 # +1 as MOT benchmark requires positive
                 ret.append(
                     np.concatenate(

--- a/boxmot/trackers/hybridsort/hybridsort.py
+++ b/boxmot/trackers/hybridsort/hybridsort.py
@@ -311,6 +311,7 @@ class KalmanBoxTracker(object):
             self.confidence_pre = self.confidence
             self.confidence = bbox[4]
         else:
+            self.det_ind = -1
             self.kf.update(bbox)
             self.confidence_pre = None
 
@@ -723,9 +724,7 @@ class HybridSort(BaseTracker):
                 we didn't notice significant difference here
                 """
                 d = trk.last_observation[:4]
-            if (trk.time_since_update < 1) and (
-                trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits
-            ):
+            if trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits:
                 # +1 as MOT benchmark requires positive
                 ret.append(
                     np.concatenate(

--- a/boxmot/trackers/ocsort/ocsort.py
+++ b/boxmot/trackers/ocsort/ocsort.py
@@ -137,7 +137,7 @@ class KalmanBoxTracker(object):
         """
         Updates the state vector with observed bbox.
         """
-        self.det_ind = det_ind
+        self.det_ind = det_ind if det_ind is not None else -1
         if bbox is not None:
             self.conf = bbox[-1]
             self.cls = cls
@@ -419,9 +419,7 @@ class OcSort(BaseTracker):
                 we didn't notice significant difference here
                 """
                 d = trk.last_observation[: 4 + self.is_obb]
-            if (trk.time_since_update < 1) and (
-                trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits
-            ):
+            if trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits:
                 # +1 as MOT benchmark requires positive
                 ret.append(
                     np.concatenate(

--- a/boxmot/trackers/strongsort/sort/track.py
+++ b/boxmot/trackers/strongsort/sort/track.py
@@ -190,6 +190,7 @@ class Track:
 
     def mark_missed(self):
         """Mark this track as missed (no association at the current time step)."""
+        self.det_ind = -1
         if self.state == TrackState.Tentative:
             self.state = TrackState.Deleted
         elif self.time_since_update > self._max_age:

--- a/boxmot/trackers/strongsort/strongsort.py
+++ b/boxmot/trackers/strongsort/strongsort.py
@@ -120,7 +120,7 @@ class StrongSort(object):
         # output bbox identities
         outputs = []
         for track in self.tracker.tracks:
-            if not track.is_confirmed() or track.time_since_update >= 1:
+            if not track.is_confirmed():
                 continue
 
             x1, y1, x2, y2 = track.to_tlbr()


### PR DESCRIPTION
## Summary
- ensure all trackers clear `det_ind` when a track is not associated with a detection
- report tracks solely based on detection indices instead of update age

## Testing
- `pre-commit run --files boxmot/trackers/boosttrack/boosttrack.py boxmot/trackers/botsort/basetrack.py boxmot/trackers/bytetrack/basetrack.py boxmot/trackers/deepocsort/deepocsort.py boxmot/trackers/hybridsort/hybridsort.py boxmot/trackers/ocsort/ocsort.py boxmot/trackers/strongsort/sort/track.py boxmot/trackers/strongsort/strongsort.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fail: ModuleNotFoundError: No module named 'cv2' and others)*
- `pip install numpy` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890f00cc9c8832d9165eb6b2e963cdb