### PR TITLE
in case of AttributeError: 'PosixPath' object has no attribute 'decode'

### DIFF
--- a/boxmot/engine/evolve.py
+++ b/boxmot/engine/evolve.py
@@ -102,7 +102,7 @@ def main(args):
     if tune.Tuner.can_restore(restore_path):
         print(f"Resuming tuning from {restore_path}...")
         tuner = tune.Tuner.restore(
-            restore_path,
+            str(restore_path),
             trainable=trainable,
             resume_errored=True,
         )


### PR DESCRIPTION
when Resuming tuning, I got this error:
```
$ boxmot tune --yolo-model '../yolo11.pt' --n-trials 300 --tracking-method bytetrack --source MOT --reid-model lmbn_n_cuhk03_d.pt
2025-09-02 13:40:38.290 | INFO     | boxmot.utils.download:download_trackeval:158 - [BoxMOT] \u2705 TrackEval already present at /data0/reference/software/miniconda-envs/boxmot/lib/python3.11/site-packages/boxmot/engine/trackeval, skipping download.
2025-09-02 13:40:38.290 | INFO     | boxmot.engine.val:run_generate_dets_embs:292 - Generating detections and embeddings for 0 sequences with model yolo11.pt
Resuming tuning from /data0/reference/software/miniconda-envs/boxmot/lib/python3.11/site-packages/runs/ray/bytetrack_tune...
<class 'pathlib.PosixPath'>
Traceback (most recent call last):
  File "/home/xilab/software/miniconda-envs/boxmot/bin/boxmot", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/boxmot/engine/cli.py", line 311, in tune
    run_tuning(args)
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/boxmot/engine/evolve.py", line 105, in main
    tuner = tune.Tuner.restore(
            ^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/ray/tune/tuner.py", line 225, in restore
    tuner_internal = TunerInternal(
                     ^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/ray/tune/impl/tuner_internal.py", line 127, in __init__
    self._restore_from_path_or_uri(
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/ray/tune/impl/tuner_internal.py", line 375, in _restore_from_path_or_uri
    path_or_uri_obj = URI(path_or_uri)
                      ^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/site-packages/ray/air/_internal/uri_utils.py", line 38, in __init__
    self._parsed = urllib.parse.urlparse(uri)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/urllib/parse.py", line 394, in urlparse
    url, scheme, _coerce_result = _coerce_args(url, scheme)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/urllib/parse.py", line 133, in _coerce_args
    return _decode_args(args) + (_encode_result,)
           ^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/urllib/parse.py", line 117, in _decode_args
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xilab/software/miniconda-envs/boxmot/lib/python3.11/urllib/parse.py", line 117, in <genexpr>
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
                 ^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'decode'

```

changing line 105 in evolve.py to:

```
str(restore_path)
``` 
 can resume the failed run successfully!