### PR TITLE
fix(strongsort): add support for Ultralytics Boxes format in update()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ boxmot/motion/cmc/*.jpg
 
 # json outputs
 *_output.json
+
+assets/DanceTrack/
+boxmot/engine/TrackEval/
+boxmot/engine/trackeval/
+environment.yml

--- a/boxmot/trackers/strongsort/strongsort.py
+++ b/boxmot/trackers/strongsort/strongsort.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import numpy as np
 from torch import device
+import torch
+from ultralytics.engine.results import Boxes 
 
 from boxmot.appearance.reid.auto_backend import ReidAutoBackend
 from boxmot.motion.cmc import get_cmc_method
@@ -68,6 +70,11 @@ class StrongSort(object):
     def update(
         self, dets: np.ndarray, img: np.ndarray, embs: np.ndarray = None
     ) -> np.ndarray:
+        #handle Ultralytics Boxes or torch.Tensor ---
+        if isinstance(dets, Boxes):
+            dets = dets.data  
+        if isinstance(dets, torch.Tensor):
+            dets = dets.cpu().numpy()
         assert isinstance(
             dets, np.ndarray
         ), f"Unsupported 'dets' input format '{type(dets)}', valid format is np.ndarray"


### PR DESCRIPTION
This PR fixes compatibility between **boxmot v15.0.2** and recent **Ultralytics YOLOv8 (≥8.1)** releases.

### Problem
- In newer versions of Ultralytics, detection results are returned as `ultralytics.engine.results.Boxes` objects instead of plain `numpy.ndarray`.
- `StrongSort.update()` strictly asserted `dets` must be a `numpy.ndarray`, causing crashes:
  ```
  AssertionError: Unsupported 'dets' input format '<class 'ultralytics.engine.results.Boxes'>'
  ```

### Solution
- Extend `StrongSort.update()` to accept:
  - `Boxes` → unwrap into `.data` (torch.Tensor).
  - `torch.Tensor` → convert to `numpy.ndarray`.
  - `numpy.ndarray` → leave unchanged.
- This makes StrongSORT robust to both old and new Ultralytics APIs.

### Example Error Fixed
```bash
boxmot track --yolo-model yolov8n.pt --tracking-method strongsort --source path/to/imgs
```

Before: ❌ crashes with `Unsupported 'dets' input format 'Boxes'`  
After: ✅ runs successfully.

---

## Changes
In `boxmot/trackers/strongsort/strongsort.py`:
```python
from ultralytics.engine.results import Boxes
import torch

if isinstance(dets, Boxes):
    dets = dets.data  # unwrap to Tensor
if isinstance(dets, torch.Tensor):
    dets = dets.cpu().numpy()
```

---

## Tested With
- `boxmot v15.0.2`
- `ultralytics 8.3.153`
- `torch 2.7.1+cu126`

---

## Notes
- This PR only addresses the `Boxes → numpy` compatibility.