### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install Poetry
         run: pip install poetry


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.10,<3.14`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.10,<3.14` (using `3.10` where a concrete pin is needed).

- `.github/workflows/update.yml`
  - `python-version: '3.8'` → `python-version: '3.10'`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.10,<3.14`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
