### PR TITLE
ci: fix release validation and restore selected version bumps

### DIFF
--- a/.github/actions/checkout-release-source/action.yml
+++ b/.github/actions/checkout-release-source/action.yml
@@ -1,0 +1,97 @@
+name: Check out release source
+description: Check out a published revision or an unpublished, immutable release candidate.
+
+inputs:
+  source_sha:
+    description: Repository revision containing the release candidate's base.
+    required: true
+  candidate_sha:
+    description: Exact unpublished candidate commit to fetch from the bundle.
+    required: false
+    default: ''
+  source_bundle:
+    description: Same-run artifact containing release-source.bundle.
+    required: false
+    default: ''
+  path:
+    description: Checkout directory relative to GITHUB_WORKSPACE.
+    required: false
+    default: '.'
+  token:
+    description: Token used to check out and optionally push the release source.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  sha:
+    description: Verified commit checked out for the release.
+    value: ${{ steps.source.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate candidate inputs
+      shell: bash
+      env:
+        CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        SOURCE_BUNDLE: ${{ inputs.source_bundle }}
+      run: |
+        if { [ -n "$CANDIDATE_SHA" ] && [ -z "$SOURCE_BUNDLE" ]; } || \
+           { [ -z "$CANDIDATE_SHA" ] && [ -n "$SOURCE_BUNDLE" ]; }; then
+          echo "candidate_sha and source_bundle must be supplied together" >&2
+          exit 1
+        fi
+
+    - name: Check out base source
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.source_sha }}
+        fetch-depth: 0
+        path: ${{ inputs.path }}
+        token: ${{ inputs.token }}
+
+    - name: Allocate candidate download directory
+      id: bundle-directory
+      if: ${{ inputs.source_bundle != '' }}
+      shell: bash
+      run: |
+        directory=$(mktemp -d "$RUNNER_TEMP/boxmot-release-source.XXXXXX")
+        echo "path=$directory" >> "$GITHUB_OUTPUT"
+
+    - name: Download candidate source
+      if: ${{ inputs.source_bundle != '' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.source_bundle }}
+        path: ${{ steps.bundle-directory.outputs.path }}
+
+    - name: Select and verify release source
+      id: source
+      shell: bash
+      working-directory: ${{ github.workspace }}/${{ inputs.path }}
+      env:
+        CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        BUNDLE_DIRECTORY: ${{ steps.bundle-directory.outputs.path }}
+      run: |
+        base_sha=$(git rev-parse HEAD)
+        expected_sha=$base_sha
+        if [ -n "$CANDIDATE_SHA" ]; then
+          git fetch --no-tags "$BUNDLE_DIRECTORY/release-source.bundle" refs/heads/release-candidate
+          fetched_sha=$(git rev-parse FETCH_HEAD)
+          if [ "$fetched_sha" != "$CANDIDATE_SHA" ]; then
+            echo "Candidate bundle contains $fetched_sha, expected $CANDIDATE_SHA" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$base_sha" "$fetched_sha"; then
+            echo "Candidate $fetched_sha does not descend from base $base_sha" >&2
+            exit 1
+          fi
+          git checkout --detach "$fetched_sha"
+          expected_sha=$CANDIDATE_SHA
+        fi
+        actual_sha=$(git rev-parse HEAD)
+        if [ "$actual_sha" != "$expected_sha" ]; then
+          echo "Checked out $actual_sha, expected $expected_sha" >&2
+          exit 1
+        fi
+        echo "sha=$actual_sha" >> "$GITHUB_OUTPUT"

--- a/.github/actions/install-ubuntu-packages/action.yml
+++ b/.github/actions/install-ubuntu-packages/action.yml
@@ -1,0 +1,42 @@
+name: Install Ubuntu packages
+description: Install CI dependencies using Ubuntu's package sources without consulting unrelated vendor repositories.
+
+inputs:
+  packages:
+    description: Whitespace-separated Ubuntu package names to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install packages from Ubuntu sources
+      shell: bash
+      env:
+        APT_ETC: /etc/apt
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -euo pipefail
+        ubuntu_sources="$APT_ETC/sources.list.d/ubuntu.sources"
+        if [ ! -s "$ubuntu_sources" ]; then
+          ubuntu_sources="$APT_ETC/sources.list"
+        fi
+        if [ ! -s "$ubuntu_sources" ]; then
+          echo "No Ubuntu APT source file found under $APT_ETC." >&2
+          exit 1
+        fi
+        read -r -a packages <<< "${PACKAGES//$'\n'/ }"
+        if [ "${#packages[@]}" -eq 0 ]; then
+          echo "At least one Ubuntu package is required." >&2
+          exit 1
+        fi
+        # Scope both commands to the runner's Ubuntu repositories. Chrome and
+        # other vendor indexes are unrelated to these CI dependencies.
+        apt_options=(
+          -o "Dir::Etc::sourcelist=$ubuntu_sources"
+          -o "Dir::Etc::sourceparts=/dev/null"
+          -o "APT::Get::List-Cleanup=0"
+          -o "APT::Update::Error-Mode=any"
+          -o "Acquire::Retries=3"
+        )
+        sudo apt-get "${apt_options[@]}" update
+        sudo apt-get "${apt_options[@]}" install --yes -- "${packages[@]}"

--- a/.github/scripts/bump_release.py
+++ b/.github/scripts/bump_release.py
@@ -1,0 +1,119 @@
+"""Prepare synchronized release versions without installing dependencies or committing."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import tomllib
+
+VERSION_FILES = frozenset({"pyproject.toml", "boxmot/__init__.py", "uv.lock"})
+BUMP_TYPES = ("major", "minor", "patch")
+_STABLE_VERSION = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+
+
+def _git(root: Path, *arguments: str) -> str:
+    """Run a read-only Git command in the candidate checkout."""
+    return subprocess.run(["git", *arguments], cwd=root, check=True, capture_output=True, text=True).stdout
+
+
+def _version_assignment(source: str) -> ast.Constant:
+    """Locate exactly one literal assignment to the runtime version."""
+    module = ast.parse(source)
+    bindings = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Name) and node.id == "__version__" and isinstance(node.ctx, (ast.Store, ast.Del))
+    ]
+    assignments = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        )
+    ]
+    if len(bindings) != 1 or len(assignments) != 1 or assignments[0] not in module.body:
+        raise ValueError("boxmot/__init__.py must contain exactly one top-level __version__ assignment.")
+    assignment = assignments[0]
+    if isinstance(assignment, ast.Assign) and len(assignment.targets) != 1:
+        raise ValueError("The __version__ assignment must not assign other names.")
+    if not isinstance(assignment.value, ast.Constant) or not isinstance(assignment.value.value, str):
+        raise ValueError("The __version__ assignment must contain a literal version string.")
+    return assignment.value
+
+
+def _versions(root: Path) -> tuple[str, str, str]:
+    """Read the project, runtime, and local editable lock-record versions."""
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    if project.get("name") != "boxmot":
+        raise ValueError("The release project must be named boxmot.")
+    runtime = _version_assignment((root / "boxmot/__init__.py").read_text(encoding="utf-8")).value
+    lock = tomllib.loads((root / "uv.lock").read_text(encoding="utf-8"))
+    packages = [package for package in lock.get("package", []) if package.get("name") == "boxmot"]
+    if len(packages) != 1 or packages[0].get("source") != {"editable": "."}:
+        raise ValueError("uv.lock must contain exactly one local editable boxmot package.")
+    versions = (project.get("version"), runtime, packages[0].get("version"))
+    for name, version in zip(("project", "runtime", "lock"), versions, strict=True):
+        if not isinstance(version, str) or _STABLE_VERSION.fullmatch(version) is None:
+            raise ValueError(f"The {name} version must use stable major.minor.patch format, got {version!r}.")
+    if len(set(versions)) != 1:
+        raise ValueError(f"Project, runtime, and lock versions must agree, got {versions!r}.")
+    return versions
+
+
+def bump_release(root: Path, bump_type: str) -> tuple[str, str]:
+    """Bump a clean candidate checkout and validate its three version-bearing files."""
+    root = Path(root).resolve()
+    if bump_type not in BUMP_TYPES:
+        raise ValueError(f"Unknown release bump {bump_type!r}; expected one of {BUMP_TYPES!r}.")
+    if _git(root, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise ValueError("Release preparation requires a clean checkout.")
+    old_version = _versions(root)[0]
+    components = [int(component) for component in old_version.split(".")]
+    index = BUMP_TYPES.index(bump_type)
+    components[index] += 1
+    components[index + 1 :] = [0] * (2 - index)
+    new_version = ".".join(map(str, components))
+
+    subprocess.run(["uv", "version", "--bump", bump_type, "--no-sync"], cwd=root, check=True)
+
+    path = root / "boxmot/__init__.py"
+    source = path.read_bytes()
+    value = _version_assignment(source.decode("utf-8"))
+    lines = source.splitlines(keepends=True)
+    # AST columns count UTF-8 bytes, including any non-ASCII text before a value.
+    start = sum(map(len, lines[: value.lineno - 1])) + value.col_offset
+    end = sum(map(len, lines[: value.end_lineno - 1])) + value.end_col_offset
+    path.write_bytes(source[:start] + f'"{new_version}"'.encode("utf-8") + source[end:])
+
+    actual_version = _versions(root)[0]
+    if actual_version != new_version:
+        raise ValueError(f"Expected a {bump_type} bump to {new_version}, got {actual_version}.")
+    changed = set(_git(root, "diff", "--name-only", "-z", "HEAD").split("\0"))
+    changed.update(_git(root, "ls-files", "--others", "--exclude-standard", "-z").split("\0"))
+    changed.discard("")
+    if changed != VERSION_FILES:
+        raise ValueError(f"Release preparation must change only {sorted(VERSION_FILES)!r}, got {sorted(changed)!r}.")
+    return old_version, new_version
+
+
+def main() -> None:
+    """Prepare the current checkout and expose candidate versions to GitHub Actions."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bump", choices=BUMP_TYPES, required=True)
+    args = parser.parse_args()
+    old_version, version = bump_release(Path.cwd(), args.bump)
+    if output := os.environ.get("GITHUB_OUTPUT"):
+        with Path(output).open("a", encoding="utf-8") as stream:
+            stream.write(f"old_version={old_version}\nversion={version}\n")
+    print(f"Prepared BoxMOT {old_version} -> {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,10 +94,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install native build dependencies
+        uses: ./.github/actions/install-ubuntu-packages
+        with:
+          packages: cmake g++ libopencv-dev libeigen3-dev
+
       - name: Install requirements
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ libopencv-dev libeigen3-dev
           uv sync --locked --no-default-groups --extra cpu --extra yolo
 
       - name: Restore HF benchmark cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install native build dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ libopencv-dev libeigen3-dev
+        uses: ./.github/actions/install-ubuntu-packages
+        with:
+          packages: cmake g++ libopencv-dev libeigen3-dev
       - name: Configure native trackers
         shell: bash
         run: |
@@ -107,10 +106,9 @@ jobs:
       - uses: ./.github/actions/prepare-ci-assets
       - name: Install native build dependencies (Linux)
         if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake g++ libopencv-dev libeigen3-dev
+        uses: ./.github/actions/install-ubuntu-packages
+        with:
+          packages: cmake g++ libopencv-dev libeigen3-dev
       - name: Install native build dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -284,11 +282,14 @@ jobs:
           name: mot17-mini-materialization
           path: ${{ github.workspace }}
 
+      - name: Install metric reporting dependencies
+        uses: ./.github/actions/install-ubuntu-packages
+        with:
+          packages: jq
+
       - name: Install requirements
         shell: bash  # for Windows compatibility
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
           uv sync --locked --no-default-groups --extra cpu --extra yolo --extra trackeval --group test
 
       - name: Check metric parity with TrackEval

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,51 +139,14 @@ jobs:
 
       - name: Smoke test v24 package and command surface
         run: |
-          docker run --rm --interactive \
+          python_args=(-I -)
+          case "${{ matrix.target }}" in
+            # Service images deliberately run their copied source via PYTHONPATH.
+            service-*) python_args=(-) ;;
+          esac
+          docker run --rm --interactive --workdir /tmp \
             ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
-            python - <<'PY'
-          import importlib.util
-
-          import boxmot
-          from boxmot.engine.cli import boxmot as boxmot_cli
-          from boxmot.engine.experiment_config import resolve_experiment_config
-
-          expected_public_api = (
-              "__version__",
-              "create_tracker",
-              "BoostTrack",
-              "BotSort",
-              "ByteTrack",
-              "DeepOcSort",
-              "HybridSort",
-              "OccluBoost",
-              "OcSort",
-              "Sam2Mot",
-              "SFSORT",
-              "StrongSort",
-          )
-          expected_cli_commands = (
-              "track",
-              "materialize",
-              "eval",
-              "tune",
-              "research",
-              "train-reid",
-              "eval-reid",
-              "compare-reid",
-              "export",
-              "build",
-          )
-
-          assert boxmot.__version__ == "24.0.0"
-          assert boxmot.__all__ == expected_public_api
-          assert tuple(boxmot_cli.commands) == expected_cli_commands
-          assert importlib.util.find_spec("boxmot.api") is None
-          assert importlib.util.find_spec("boxmot.data") is None
-          experiment = resolve_experiment_config("mot17/ablation-yolox-lmbn.yaml")
-          assert experiment["detector"]["id"] == "yolox-x-mot17"
-          assert experiment["reid"]["id"] == "lmbn-n-duke"
-          PY
+            python "${python_args[@]}" < tests/ci/release_contract.py
 
       - name: Smoke test CPU CLI image
         if: matrix.target == 'cli-cpu'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,35 +52,40 @@ on:
     types: [published]
 
 jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.images.outputs.matrix }}
+    steps:
+      - name: Select images supported by the configured runners
+        id: images
+        env:
+          ENABLE_GPU_SERVICE: ${{ vars.BOXMOT_GPU_SERVICE_CI }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          images = [
+              {"target": "cli-gpu", "repository": "boxmot/boxmot", "tag_suffix": "", "runner": "ubuntu-latest", "timeout_minutes": 90},
+              {"target": "cli-cpu", "repository": "boxmot/boxmot", "tag_suffix": "-cpu", "runner": "ubuntu-latest", "timeout_minutes": 90},
+              {"target": "service-cpu", "repository": "boxmot/boxmot-service", "tag_suffix": "", "runner": "ubuntu-latest", "timeout_minutes": 90},
+              {"target": "service-gpu", "repository": "boxmot/boxmot-service", "tag_suffix": "-gpu", "runner": "gpu-latest", "timeout_minutes": 120},
+          ]
+          if os.environ.get("ENABLE_GPU_SERVICE") != "true":
+              images = [image for image in images if image["target"] != "service-gpu"]
+              print("Skipping service-gpu: BOXMOT_GPU_SERVICE_CI is not enabled.")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"matrix={json.dumps({'include': images})}\n")
+          PY
+
   build-and-push:
+    needs: prepare-matrix
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: cli-gpu
-            repository: boxmot/boxmot
-            tag_suffix: ""
-            runner: ubuntu-latest
-            timeout_minutes: 90
-          - target: cli-cpu
-            repository: boxmot/boxmot
-            tag_suffix: -cpu
-            runner: ubuntu-latest
-            timeout_minutes: 90
-          - target: service-cpu
-            repository: boxmot/boxmot-service
-            tag_suffix: ""
-            runner: ubuntu-latest
-            timeout_minutes: 90
-          - target: service-gpu
-            repository: boxmot/boxmot-service
-            tag_suffix: -gpu
-            # This repository label must select a Linux runner with an NVIDIA
-            # GPU, driver, Docker, and the NVIDIA Container Toolkit installed.
-            runner: gpu-latest
-            timeout_minutes: 120
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
       # Bootstrap from workflow code, including when manually rebuilding older source.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,16 @@ on:
         default: false
   workflow_call:
     inputs:
+      source_base:
+        description: 'Published base revision when source_ref is an unpublished candidate'
+        required: false
+        type: string
+        default: ''
+      source_bundle:
+        description: 'Same-run artifact containing release-source.bundle'
+        required: false
+        type: string
+        default: ''
       source_ref:
         description: 'Commit SHA to build and smoke-test'
         required: true
@@ -73,11 +83,18 @@ jobs:
             timeout_minutes: 120
 
     steps:
-      - name: Checkout repository
+      # Bootstrap from workflow code, including when manually rebuilding older source.
+      - name: Bootstrap release checkout action
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_ref || github.event.release.tag_name }}
-          fetch-depth: 0
+          ref: ${{ github.workflow_sha }}
+
+      - name: Checkout repository
+        uses: ./.github/actions/checkout-release-source
+        with:
+          source_sha: ${{ inputs.source_base || inputs.source_ref || github.event.release.tag_name }}
+          candidate_sha: ${{ inputs.source_bundle && inputs.source_ref || '' }}
+          source_bundle: ${{ inputs.source_bundle }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -137,7 +154,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=${{ matrix.target }}
 
-      - name: Smoke test v24 package and command surface
+      - name: Smoke test release package and command surface
         run: |
           python_args=(-I -)
           case "${{ matrix.target }}" in
@@ -146,7 +163,7 @@ jobs:
           esac
           docker run --rm --interactive --workdir /tmp \
             ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
-            python "${python_args[@]}" < tests/ci/release_contract.py
+            python "${python_args[@]}" --expected-version "${{ env.VERSION }}" < tests/ci/release_contract.py
 
       - name: Smoke test CPU CLI image
         if: matrix.target == 'cli-cpu'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,36 +11,140 @@ on:
         options:
           - pypi
           - testpypi
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+
+# Keep another release from publishing the same next version while this one runs.
+concurrency:
+  group: pypi-release-${{ inputs.pypi }}
+  cancel-in-progress: false
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 jobs:
+  prepare-release:
+    name: Prepare the selected version without changing the remote branch
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      candidate_sha: ${{ steps.candidate.outputs.sha }}
+    steps:
+      - name: Checkout the requested revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Require the current branch revision
+        env:
+          SOURCE_BRANCH: ${{ github.ref_name }}
+          BASE_SHA: ${{ github.sha }}
+          TARGET_REPOSITORY: ${{ inputs.pypi }}
+        run: |
+          if [ "$GITHUB_REF_TYPE" != branch ]; then
+            echo "Release dispatch must select a branch." >&2
+            exit 1
+          fi
+          case "$TARGET_REPOSITORY" in
+            pypi|testpypi) ;;
+            *) echo "Unsupported package repository: $TARGET_REPOSITORY" >&2; exit 1 ;;
+          esac
+          remote_sha=$(git ls-remote --exit-code origin "refs/heads/$SOURCE_BRANCH" | cut -f1)
+          if [ "$remote_sha" != "$BASE_SHA" ]; then
+            echo "The selected branch has moved. Start a new release from its current revision." >&2
+            exit 1
+          fi
+
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-ci-python
+        with:
+          python-version: '3.11'
+
+      - name: Bump project, package, and lockfile versions
+        id: bump
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: python .github/scripts/bump_release.py --bump "$BUMP_TYPE"
+
+      - name: Preserve the exact candidate commit for every release gate
+        id: candidate
+        env:
+          BASE_SHA: ${{ github.sha }}
+          OLD_VERSION: ${{ steps.bump.outputs.old_version }}
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config --local user.name 'github-actions[bot]'
+          git checkout -b release-candidate
+          git add pyproject.toml boxmot/__init__.py uv.lock
+          git commit -m "ci: bump version from $OLD_VERSION to $RELEASE_VERSION"
+          git bundle create "$RUNNER_TEMP/release-source.bundle" "$BASE_SHA..refs/heads/release-candidate"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the unpublished release candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-source
+          path: ${{ runner.temp }}/release-source.bundle
+          if-no-files-found: error
+          retention-days: 30
+
   release-gates:
-    name: Build and validate the release distributions
+    name: Build and validate the bumped release distributions
+    needs: prepare-release
     uses: ./.github/workflows/wheels.yml
     with:
+      source_sha: ${{ github.sha }}
+      candidate_sha: ${{ needs.prepare-release.outputs.candidate_sha }}
+      source_bundle: release-source
       upload_artifacts: true
 
   docker-gates:
-    name: Smoke-test release Docker images before publication
-    needs: release-gates
+    name: Smoke-test bumped release Docker images before publication
+    needs: [prepare-release, release-gates]
     uses: ./.github/workflows/docker.yml
     with:
-      source_ref: ${{ github.sha }}
+      source_base: ${{ github.sha }}
+      source_ref: ${{ needs.prepare-release.outputs.candidate_sha }}
+      source_bundle: release-source
       release_tag: v${{ needs.release-gates.outputs.version }}
       push_images: false
 
   pypi-upload:
-    name: Publish gated v24 distributions
-    needs: [release-gates, docker-gates]
+    name: Publish gated distributions and record the successful release
+    needs: [prepare-release, release-gates, docker-gates]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    env:
+      BASE_SHA: ${{ github.sha }}
+      SOURCE_BRANCH: ${{ github.ref_name }}
+      CANDIDATE_SHA: ${{ needs.prepare-release.outputs.candidate_sha }}
+      RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+      TARGET_REPOSITORY: ${{ inputs.pypi }}
     steps:
-      - name: Checkout the gated revision
+      - name: Checkout release orchestration
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
+
+      - name: Restore the candidate that passed every release gate
+        uses: ./.github/actions/checkout-release-source
+        with:
+          source_sha: ${{ github.sha }}
+          candidate_sha: ${{ needs.prepare-release.outputs.candidate_sha }}
+          source_bundle: release-source
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-ci-python
@@ -55,10 +159,11 @@ jobs:
 
       - name: Verify gated artifact checksums and version
         env:
-          RELEASE_VERSION: ${{ needs.release-gates.outputs.version }}
+          GATED_VERSION: ${{ needs.release-gates.outputs.version }}
         run: |
           (cd dist && sha256sum --check SHA256SUMS)
           python - <<'PY'
+          import ast
           import email
           import os
           import pathlib
@@ -67,7 +172,15 @@ jobs:
 
           release_version = os.environ["RELEASE_VERSION"]
           source_version = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
-          assert release_version == source_version == "24.0.0"
+          assert release_version == source_version == os.environ["GATED_VERSION"]
+          module = ast.parse(pathlib.Path("boxmot/__init__.py").read_text())
+          package_version = next(
+              ast.literal_eval(node.value)
+              for node in module.body
+              if isinstance(node, ast.Assign)
+              and any(isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets)
+          )
+          assert package_version == release_version
           wheels = list(pathlib.Path("dist").glob("*.whl"))
           assert len(wheels) == 1, f"expected one gated wheel, found {wheels}"
           with zipfile.ZipFile(wheels[0]) as archive:
@@ -76,25 +189,50 @@ jobs:
           assert metadata["Version"] == release_version
           PY
 
-      - name: Publish the gated distributions
+      - name: Check the destination immediately before publication
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
-          if [ "${{ inputs.pypi }}" == "pypi" ]; then
-            uv publish dist/*.whl dist/*.tar.gz --token "${{ secrets.PYPI_TOKEN }}"
-          else
-            uv publish --index testpypi dist/*.whl dist/*.tar.gz --token "${{ secrets.TEST_PYPI_TOKEN }}"
+          if [ "$TARGET_REPOSITORY" = pypi ] && [ -z "$RELEASE_TOKEN" ]; then
+            echo "RELEASE_PAT is required for the version commit, tag, and release." >&2
+            exit 1
+          fi
+          remote_sha=$(git ls-remote --exit-code origin "refs/heads/$SOURCE_BRANCH" | cut -f1)
+          if [ "$remote_sha" != "$BASE_SHA" ]; then
+            echo "The branch changed during validation. No package was published; start a new release." >&2
+            exit 1
+          fi
+          if [ "$TARGET_REPOSITORY" = pypi ]; then
+            existing_tag=$(git ls-remote origin "refs/tags/v$RELEASE_VERSION")
+            if [ -n "$existing_tag" ]; then
+              echo "Release tag v$RELEASE_VERSION already exists. No package was published." >&2
+              exit 1
+            fi
           fi
 
-      - name: Create code release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Publish the gated distributions
         env:
-          # A PAT is required so the release.published event can start the
-          # release-only Docker workflow; GITHUB_TOKEN suppresses chained runs.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-        with:
-          tag_name: v${{ needs.release-gates.outputs.version }}
-          release_name: Release v${{ needs.release-gates.outputs.version }}
-          commitish: ${{ github.sha }}
-          draft: false
-          prerelease: false
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          if [ "$TARGET_REPOSITORY" = pypi ]; then
+            UV_PUBLISH_TOKEN="$PYPI_TOKEN" uv publish dist/*.whl dist/*.tar.gz
+          else
+            UV_PUBLISH_TOKEN="$TEST_PYPI_TOKEN" uv publish --index testpypi dist/*.whl dist/*.tar.gz
+          fi
+
+      - name: Push the successful version commit and tag
         if: ${{ success() && inputs.pypi == 'pypi' }}
+        run: |
+          git tag "v$RELEASE_VERSION" "$CANDIDATE_SHA"
+          if ! git push --atomic origin "$CANDIDATE_SHA:refs/heads/$SOURCE_BRANCH" "refs/tags/v$RELEASE_VERSION"; then
+            echo "::error::PyPI publication succeeded, but the release commit and tag could not be pushed. Recover the tested candidate from the release-source artifact; do not rebuild or force-push a different commit."
+            exit 1
+          fi
+
+      - name: Create code release at the published commit
+        if: ${{ success() && inputs.pypi == 'pypi' }}
+        env:
+          # A PAT allows release.published to start the Docker publishing workflow.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: gh release create "v$RELEASE_VERSION" --verify-tag --title "Release v$RELEASE_VERSION" --notes "Release v$RELEASE_VERSION"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -138,6 +138,12 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
+      - name: Checkout release checks
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: source
+
       - uses: actions/download-artifact@v4
         with:
           name: boxmot-release-candidate
@@ -155,33 +161,14 @@ jobs:
       - name: Smoke-test v24 imports and CLI
         working-directory: ${{ runner.temp }}
         run: |
-          python - <<'PY'
-          import importlib.util
+          python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" --check-cli-help
+          python -I - <<'PY'
           import sys
 
-          import boxmot
           import boxmot.engine.materialization.workflow
           import boxmot.engine.tracking.sinks
           import boxmot.engine.tracking.sources
 
-          expected = (
-              "__version__",
-              "create_tracker",
-              "BoostTrack",
-              "BotSort",
-              "ByteTrack",
-              "DeepOcSort",
-              "HybridSort",
-              "OccluBoost",
-              "OcSort",
-              "Sam2Mot",
-              "SFSORT",
-              "StrongSort",
-          )
-          assert boxmot.__version__ == "24.0.0"
-          assert boxmot.__all__ == expected
-          assert importlib.util.find_spec("boxmot.api") is None
-          assert importlib.util.find_spec("boxmot.data") is None
           assert "ultralytics" not in sys.modules
           assert not any(name.startswith("boxmot.native.trackers") for name in sys.modules)
           PY
@@ -191,9 +178,6 @@ jobs:
             echo "Removed generate command is still present" >&2
             exit 1
           fi
-          for command in track materialize eval tune research train-reid eval-reid compare-reid export build; do
-            boxmot "$command" --help > "boxmot-$command-help.txt"
-          done
           for module in \
             boxmot.engine.commands.reid.ablation \
             boxmot.engine.commands.reid.human_pretrain \

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,11 +41,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      # Load the local action from this workflow's revision before selecting source.
+      # Load release setup actions from this workflow's revision before selecting source.
       - name: Bootstrap release checkout action
         uses: actions/checkout@v4
         with:
           ref: ${{ github.workflow_sha }}
+
+      - name: Install native build dependencies
+        uses: ./.github/actions/install-ubuntu-packages
+        with:
+          packages: cmake g++ libopencv-dev libeigen3-dev
 
       - name: Check out release source
         uses: ./.github/actions/checkout-release-source
@@ -58,11 +63,6 @@ jobs:
         uses: ./.github/actions/setup-ci-python
         with:
           python-version: '3.11'
-
-      - name: Install native build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes cmake g++ libopencv-dev libeigen3-dev
 
       - name: Install release-gate dependencies
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,21 @@ name: Build and Smoke-Test Release Wheel
 on:
   workflow_call:
     inputs:
+      source_sha:
+        description: 'Published base revision; defaults to the triggering commit'
+        required: false
+        type: string
+        default: ''
+      candidate_sha:
+        description: 'Exact unpublished candidate commit in source_bundle'
+        required: false
+        type: string
+        default: ''
+      source_bundle:
+        description: 'Same-run artifact containing release-source.bundle'
+        required: false
+        type: string
+        default: ''
       upload_artifacts:
         description: 'Upload the gated distributions for the calling workflow'
         required: false
@@ -26,9 +41,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      # Load the local action from this workflow's revision before selecting source.
+      - name: Bootstrap release checkout action
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
+
+      - name: Check out release source
+        uses: ./.github/actions/checkout-release-source
+        with:
+          source_sha: ${{ inputs.source_sha || github.sha }}
+          candidate_sha: ${{ inputs.candidate_sha }}
+          source_bundle: ${{ inputs.source_bundle }}
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-ci-python
@@ -58,15 +82,23 @@ jobs:
         run: uv run --no-sync mkdocs build --strict
 
   build:
-    name: Build v24 distributions once
+    name: Build release distributions once
     needs: source_gates
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Bootstrap release checkout action
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
+
+      - name: Check out release source
+        uses: ./.github/actions/checkout-release-source
+        with:
+          source_sha: ${{ inputs.source_sha || github.sha }}
+          candidate_sha: ${{ inputs.candidate_sha }}
+          source_bundle: ${{ inputs.source_bundle }}
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-ci-python
@@ -88,7 +120,6 @@ jobs:
           import zipfile
 
           version = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
-          assert version == "24.0.0", f"release workflow is for v24.0.0, got {version}"
           wheels = list(pathlib.Path("dist").glob("*.whl"))
           sdists = list(pathlib.Path("dist").glob("*.tar.gz"))
           assert len(wheels) == 1, f"expected one wheel, found {wheels}"
@@ -138,10 +169,17 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - name: Checkout release checks
+      - name: Bootstrap release checkout action
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
+
+      - name: Checkout release checks
+        uses: ./.github/actions/checkout-release-source
+        with:
+          source_sha: ${{ inputs.source_sha || github.sha }}
+          candidate_sha: ${{ inputs.candidate_sha }}
+          source_bundle: ${{ inputs.source_bundle }}
           path: source
 
       - uses: actions/download-artifact@v4
@@ -158,10 +196,13 @@ jobs:
           python -m pip install --extra-index-url https://download.pytorch.org/whl/cpu candidate/*.whl
           python -m pip check
 
-      - name: Smoke-test v24 imports and CLI
+      - name: Smoke-test release imports and CLI
         working-directory: ${{ runner.temp }}
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" --check-cli-help
+          python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" \
+            --expected-version "$RELEASE_VERSION" --check-cli-help
           python -I - <<'PY'
           import sys
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,8 +33,16 @@ FROM build-base AS cli-build-base
 
 # YOLOX compiles its fast_cocoeval extension when the yolo extra is selected.
 # The compiler remains in CLI builders and is not copied into runtime images.
+# Wheel smoke tests load the prebuilt native libraries in these builders, so
+# they need the same OpenCV runtime dependencies as the final CLI images.
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends g++ \
+    && apt-get install --yes --no-install-recommends \
+        g++ \
+        libopencv-calib3d406 \
+        libopencv-core406 \
+        libopencv-dnn406 \
+        libopencv-imgproc406 \
+        libopencv-video406 \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,8 +51,14 @@ uv lock
 
 ## Publish
 
-GitHub Actions builds, smoke-tests, and pushes all four targets when a GitHub
-release is published. The same workflow can be dispatched manually with an
+GitHub Actions builds, smoke-tests, and pushes `cli-gpu`, `cli-cpu`, and
+`service-cpu` when a GitHub release is published. The `service-gpu` target is
+disabled by default. Enable it by setting the repository Actions variable
+`BOXMOT_GPU_SERVICE_CI=true` after registering a `gpu-latest` Linux NVIDIA runner
+with Docker and the NVIDIA Container Toolkit. This also enables its release
+gate and manual-workflow checks.
+
+The same workflow can be dispatched manually with an
 exact commit SHA and `v<version>` release tag; manual runs validate only unless
 `push_images` is explicitly enabled. Pull requests and branch pushes do not
 build or publish images. Each target is pushed only after its smoke test passes,

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -90,12 +90,37 @@ instead of the generic bounding-box smoke command.
 
 ## Release gates
 
-The publish workflow never rebuilds or bumps the package. It publishes the
-exact `24.0.0` wheel and source distribution produced by the reusable wheel
-workflow after the full tests, strict documentation build, native checks, and
-clean-wheel imports on Python 3.10 through 3.13 pass. It also calls the Docker
-workflow in non-pushing mode before PyPI upload. A published `v24.0.0` release
-then invokes that same Docker workflow in pushing mode.
+Start the **Publish to PyPI** workflow on the current branch revision and select
+`patch`, `minor`, or `major` under **Version bump type**. The default is `patch`.
+For example, `24.0.0` becomes `24.0.1`, `24.1.0`, or `25.0.0`, respectively.
+
+Preparation first verifies that `pyproject.toml`, `boxmot/__init__.py`, and the
+local editable `boxmot` record in `uv.lock` agree. It uses
+`uv version --bump <type> --no-sync` to update the project and lockfile, then
+synchronizes the runtime version. The resulting candidate commit is retained
+in the `release-source` bundle artifact without pushing the branch or a tag.
+
+Every release gate restores that exact candidate. The reusable wheel workflow
+runs the full tests, strict documentation build, native checks, and clean-wheel
+imports on Python 3.10 through 3.13. Docker validates all four images without
+pushing them. Package checks compare the requested release version with the
+candidate and installed artifacts; they do not pin a particular version.
+
+After these gates pass, the workflow publishes the checksummed wheel and source
+distribution. Successful **PyPI** publication is followed by an atomic push of
+the tested version commit and its `v<version>` tag, then a GitHub release at that
+commit. The release event starts Docker image publication. **TestPyPI** runs
+the same preparation and validation but leaves the remote branch, tags, and
+GitHub releases unchanged.
+
+Release runs targeting the same package repository are serialized. The workflow
+checks that the branch still points at the selected revision before preparation
+and immediately before publication. It rejects an existing release tag before
+PyPI publication. The final branch push uses a normal fast-forward update. If
+publication succeeds but that push fails,
+recover the tested candidate from the bundle artifact instead of rebuilding or
+force-pushing another commit. PyPI publication requires `RELEASE_PAT` with
+permission to push the version commit and tag and create the release.
 
 The `service-gpu` smoke runs on the `gpu-latest` runner label and requires a
 Linux NVIDIA host with Docker and the NVIDIA Container Toolkit. It exposes the

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -61,6 +61,13 @@ CI invokes `.venv/bin` commands directly after syncing because uv does not
 persist an activated optional extra. A later plain `uv run` could otherwise
 re-sync without the selected CPU/CUDA profile.
 
+Ubuntu jobs install system dependencies through
+`.github/actions/install-ubuntu-packages`. Both APT update and installation use
+the runner's Ubuntu source file, so unrelated vendor repositories such as
+Google Chrome cannot block native builds or metric reporting. Package hash and
+signature checks remain enabled. Downloads retry up to three times, and an
+Ubuntu repository failure still fails the job.
+
 The `materialize` job creates the MOT17-mini detection and embedding build once
 on Python 3.12. An exact-key Actions cache reuses that build and its resolved
 model artifacts on later runs only when the lockfile, package sources, dataset

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -102,9 +102,10 @@ in the `release-source` bundle artifact without pushing the branch or a tag.
 
 Every release gate restores that exact candidate. The reusable wheel workflow
 runs the full tests, strict documentation build, native checks, and clean-wheel
-imports on Python 3.10 through 3.13. Docker validates all four images without
-pushing them. Package checks compare the requested release version with the
-candidate and installed artifacts; they do not pin a particular version.
+imports on Python 3.10 through 3.13. Docker validates `cli-cpu`, `cli-gpu`, and
+`service-cpu` by default, without pushing them. Package checks compare the
+requested release version with the candidate and installed artifacts; they do
+not pin a particular version.
 
 After these gates pass, the workflow publishes the checksummed wheel and source
 distribution. Successful **PyPI** publication is followed by an atomic push of
@@ -122,9 +123,13 @@ recover the tested candidate from the bundle artifact instead of rebuilding or
 force-pushing another commit. PyPI publication requires `RELEASE_PAT` with
 permission to push the version commit and tag and create the release.
 
-The `service-gpu` smoke runs on the `gpu-latest` runner label and requires a
-Linux NVIDIA host with Docker and the NVIDIA Container Toolkit. It exposes the
-GPU to the container, performs CUDA-backed ReID enrichment through the HTTP
-service, and verifies that the service owns an active CUDA context. The CPU
+The `service-gpu` target is disabled by default so releases can run without a
+GPU runner. To enable its build, smoke test, and image publication, set the
+repository Actions variable `BOXMOT_GPU_SERVICE_CI` to `true` after registering
+a `gpu-latest` Linux NVIDIA runner with Docker and the NVIDIA Container Toolkit.
+This setting applies to release gates, published releases, and manual Docker runs.
+The enabled smoke exposes the GPU to the container, performs CUDA-backed ReID
+enrichment through the HTTP service, and verifies that the service owns an
+active CUDA context. The CPU
 service smoke uses the CPU-only Torch image and exercises the same `/v1`
 request boundary without CUDA.

--- a/tests/ci/python_api_smoke.py
+++ b/tests/ci/python_api_smoke.py
@@ -6,10 +6,10 @@ import numpy as np
 import torch
 from click.testing import CliRunner
 
-import boxmot
 from boxmot import ByteTrack, create_tracker
 from boxmot.engine.cli import boxmot as boxmot_cli
 from boxmot.trackers import TrackerSpec
+from tests.ci.release_contract import EXPECTED_CLI_COMMANDS, check_release_contract
 
 
 def test_python_api_smoke() -> None:
@@ -17,24 +17,7 @@ def test_python_api_smoke() -> None:
 
     assert torch.version.cuda is None, f"Expected CPU-only PyTorch, got torch {torch.__version__}"
     assert not torch.cuda.is_available()
-    assert boxmot.__version__ == "24.0.0"
-    assert boxmot.__all__ == (
-        "__version__",
-        "create_tracker",
-        "BoostTrack",
-        "BotSort",
-        "ByteTrack",
-        "DeepOcSort",
-        "HybridSort",
-        "OccluBoost",
-        "OcSort",
-        "Sam2Mot",
-        "SFSORT",
-        "StrongSort",
-    )
-    assert not hasattr(boxmot, "BoxMOT")
-    assert not hasattr(boxmot, "Detector")
-    assert not hasattr(boxmot, "ReIDModel")
+    check_release_contract()
 
     tracker = create_tracker(TrackerSpec("bytetrack"))
     assert isinstance(tracker, ByteTrack)
@@ -53,17 +36,6 @@ def test_cli_command_surface_smoke() -> None:
     result = CliRunner().invoke(boxmot_cli, ["--help"])
 
     assert result.exit_code == 0, result.output
-    for command in (
-        "track",
-        "materialize",
-        "eval",
-        "tune",
-        "research",
-        "train-reid",
-        "eval-reid",
-        "compare-reid",
-        "export",
-        "build",
-    ):
+    for command in EXPECTED_CLI_COMMANDS:
         assert command in result.output
     assert "generate" not in result.output

--- a/tests/ci/python_api_smoke.py
+++ b/tests/ci/python_api_smoke.py
@@ -1,4 +1,4 @@
-"""Clean-install smoke tests for the coordinated v24 public cutover."""
+"""Clean-install smoke tests for the public package and command interface."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ def test_python_api_smoke() -> None:
 
     assert torch.version.cuda is None, f"Expected CPU-only PyTorch, got torch {torch.__version__}"
     assert not torch.cuda.is_available()
+    # Compare runtime to installed metadata; refresh editable installs after a bump.
     check_release_contract()
 
     tracker = create_tracker(TrackerSpec("bytetrack"))

--- a/tests/ci/release_contract.py
+++ b/tests/ci/release_contract.py
@@ -1,0 +1,81 @@
+"""Shared installed-package release checks, runnable without the source package."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+
+EXPECTED_VERSION = "24.0.0"
+EXPECTED_PUBLIC_API = (
+    "__version__",
+    "create_tracker",
+    "BoostTrack",
+    "BotSort",
+    "ByteTrack",
+    "DeepOcSort",
+    "HybridSort",
+    "OccluBoost",
+    "OcSort",
+    "Sam2Mot",
+    "SFSORT",
+    "StrongSort",
+)
+EXPECTED_CLI_COMMANDS = (
+    "track",
+    "materialize",
+    "time-variant",
+    "eval",
+    "tune",
+    "research",
+    "train-reid",
+    "eval-reid",
+    "compare-reid",
+    "export",
+    "build",
+)
+
+
+def check_release_contract() -> None:
+    """Check the independent release expectations through public discovery APIs."""
+    import click
+
+    import boxmot
+    from boxmot.engine.cli import boxmot as boxmot_cli
+    from boxmot.engine.experiment_config import resolve_experiment_config
+
+    assert boxmot.__version__ == EXPECTED_VERSION, (
+        f"Package version: expected {EXPECTED_VERSION!r}, got {boxmot.__version__!r}"
+    )
+    assert boxmot.__all__ == EXPECTED_PUBLIC_API, (
+        f"Public API: expected {EXPECTED_PUBLIC_API!r}, got {boxmot.__all__!r}"
+    )
+    with click.Context(boxmot_cli) as context:
+        commands = tuple(boxmot_cli.list_commands(context))
+    assert commands == EXPECTED_CLI_COMMANDS, (
+        f"CLI commands: expected {EXPECTED_CLI_COMMANDS!r}, got {commands!r}"
+    )
+    assert importlib.util.find_spec("boxmot.api") is None
+    assert importlib.util.find_spec("boxmot.data") is None
+    for name in ("BoxMOT", "Detector", "ReIDModel"):
+        assert not hasattr(boxmot, name), f"Removed public alias remains: {name}"
+    experiment = resolve_experiment_config("mot17/ablation-yolox-lmbn.yaml")
+    assert experiment["detector"]["id"] == "yolox-x-mot17"
+    assert experiment["reid"]["id"] == "lmbn-n-duke"
+
+
+def check_cli_help() -> None:
+    """Resolve each advertised command through the installed console entrypoint."""
+    for command in EXPECTED_CLI_COMMANDS:
+        result = subprocess.run(["boxmot", command, "--help"], capture_output=True, text=True, check=False)
+        assert result.returncode == 0, f"boxmot {command} --help failed:\n{result.stdout}\n{result.stderr}"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check-cli-help", action="store_true", help="Also exercise every installed command's help.")
+    args = parser.parse_args()
+    check_release_contract()
+    if args.check_cli_help:
+        check_cli_help()
+    print("Release public API, CLI, and packaged configuration checks passed.")

--- a/tests/ci/release_contract.py
+++ b/tests/ci/release_contract.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import importlib.util
 import subprocess
 
-EXPECTED_VERSION = "24.0.0"
 EXPECTED_PUBLIC_API = (
     "__version__",
     "create_tracker",
@@ -36,16 +36,23 @@ EXPECTED_CLI_COMMANDS = (
 )
 
 
-def check_release_contract() -> None:
-    """Check the independent release expectations through public discovery APIs."""
+def check_release_contract(expected_version: str | None = None) -> None:
+    """Check the requested release or installed version and public discovery APIs.
+
+    Explicit release versions also support source-only service images without
+    distribution metadata. Otherwise, the installed distribution is the version
+    authority; editable installs must be refreshed after source version changes.
+    """
     import click
 
     import boxmot
     from boxmot.engine.cli import boxmot as boxmot_cli
     from boxmot.engine.experiment_config import resolve_experiment_config
 
-    assert boxmot.__version__ == EXPECTED_VERSION, (
-        f"Package version: expected {EXPECTED_VERSION!r}, got {boxmot.__version__!r}"
+    if expected_version is None:
+        expected_version = importlib.metadata.version("boxmot")
+    assert boxmot.__version__ == expected_version, (
+        f"Package version: expected {expected_version!r}, got {boxmot.__version__!r}"
     )
     assert boxmot.__all__ == EXPECTED_PUBLIC_API, (
         f"Public API: expected {EXPECTED_PUBLIC_API!r}, got {boxmot.__all__!r}"
@@ -73,9 +80,13 @@ def check_cli_help() -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected-version",
+        help="Expected runtime version; defaults to the installed BoxMOT distribution version.",
+    )
     parser.add_argument("--check-cli-help", action="store_true", help="Also exercise every installed command's help.")
     args = parser.parse_args()
-    check_release_contract()
+    check_release_contract(expected_version=args.expected_version)
     if args.check_cli_help:
         check_cli_help()
     print("Release public API, CLI, and packaged configuration checks passed.")

--- a/tests/unit/test_docker_native_runtime.py
+++ b/tests/unit/test_docker_native_runtime.py
@@ -1,0 +1,73 @@
+"""Check native loader dependencies across Docker stage inheritance."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+DOCKERFILE = Path(__file__).resolve().parents[2] / "docker" / "Dockerfile"
+OPENCV_RUNTIME_PACKAGES = frozenset(
+    {
+        "libopencv-calib3d406",
+        "libopencv-core406",
+        "libopencv-dnn406",
+        "libopencv-imgproc406",
+        "libopencv-video406",
+    }
+)
+
+
+def _stages() -> dict[str, tuple[str, list[str]]]:
+    """Resolve named FROM stages and join continued Docker instructions."""
+    source = DOCKERFILE.read_text(encoding="utf-8").replace("\\\n", " ")
+    headers = list(re.finditer(r"^FROM (\S+) AS (\S+)\s*$", source, re.MULTILINE))
+    return {
+        header[2]: (
+            header[1],
+            source[header.end() : headers[index + 1].start() if index + 1 < len(headers) else len(source)].splitlines(),
+        )
+        for index, header in enumerate(headers)
+    }
+
+
+def _installed_packages(instruction: str) -> set[str]:
+    """Read explicit apt packages from an instruction, excluding command flags."""
+    match = re.search(r"apt-get install\s+(.+?)(?:&&|;|$)", instruction)
+    return {word for word in shlex.split(match[1]) if not word.startswith("-")} if match else set()
+
+
+def _packages_at_end(stages: dict[str, tuple[str, list[str]]], name: str) -> set[str]:
+    """Only FROM inherits system packages; COPY imports files, not apt installs."""
+    if name not in stages:
+        return set()
+    parent, instructions = stages[name]
+    packages = _packages_at_end(stages, parent)
+    for instruction in instructions:
+        packages.update(_installed_packages(instruction))
+    return packages
+
+
+def test_native_library_smokes_have_opencv_before_loading() -> None:
+    """A later runtime stage cannot satisfy a builder's earlier ctypes smoke."""
+    stages = _stages()
+    checked = []
+    for name, (parent, instructions) in stages.items():
+        packages = _packages_at_end(stages, parent)
+        for instruction in instructions:
+            before_load = instruction.split("ctypes.CDLL", 1)[0]
+            packages.update(_installed_packages(before_load))
+            if "ctypes.CDLL" in instruction:
+                missing = OPENCV_RUNTIME_PACKAGES - packages
+                assert not missing, f"{name} loads native libraries without runtime packages: {sorted(missing)}"
+                checked.append(name)
+    assert checked, "Retain native-library load validation in CLI wheel builders."
+
+
+@pytest.mark.parametrize("target", ("cli-cpu", "cli-gpu", "default"))
+def test_cli_targets_inherit_opencv_runtime_packages(target: str) -> None:
+    """The published images and default target can load their native artifacts."""
+    missing = OPENCV_RUNTIME_PACKAGES - _packages_at_end(_stages(), target)
+    assert not missing, f"{target} lacks native runtime packages: {sorted(missing)}"

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -18,6 +18,7 @@ DOCKER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker.yml"
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 WHEEL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "wheels.yml"
+CHECKOUT_ACTION = REPO_ROOT / ".github" / "actions" / "checkout-release-source" / "action.yml"
 
 
 def _docker_job() -> dict:
@@ -56,17 +57,19 @@ def test_manual_image_rebuild_is_explicit_and_safe_by_default() -> None:
     assert "description: 'Exact v-prefixed release tag to validate'" in workflow
     assert "push_images:\n        description: 'Push validated images to Docker Hub'" in workflow
     assert "type: boolean\n        default: false" in workflow
-    assert "fetch-depth: 0" in workflow
+    action = yaml.safe_load(CHECKOUT_ACTION.read_text(encoding="utf-8"))
+    checkout = next(step for step in action["runs"]["steps"] if step.get("uses") == "actions/checkout@v4")
+    assert checkout["with"]["fetch-depth"] == 0
     assert "Manual publishing requires $RELEASE_TAG to point at $source_sha" in workflow
 
 
 def test_every_docker_image_checks_the_exact_v24_surface() -> None:
     job = _docker_job()
-    step = next(step for step in job["steps"] if step.get("name") == "Smoke test v24 package and command surface")
+    step = next(step for step in job["steps"] if step.get("name") == "Smoke test release package and command surface")
     script = step["run"]
 
     assert "if:" not in step
-    assert 'python "${python_args[@]}" < tests/ci/release_contract.py' in script
+    assert 'python "${python_args[@]}" --expected-version "${{ env.VERSION }}" < tests/ci/release_contract.py' in script
     assert "--workdir /tmp" in script
 
 
@@ -74,7 +77,7 @@ def test_every_docker_image_checks_the_exact_v24_surface() -> None:
 def test_docker_release_smoke_preserves_each_images_import_context(tmp_path: Path, target: str) -> None:
     """Execute the workflow's Python flags against a source-only package fixture."""
     step = next(
-        step for step in _docker_job()["steps"] if step.get("name") == "Smoke test v24 package and command surface"
+        step for step in _docker_job()["steps"] if step.get("name") == "Smoke test release package and command surface"
     )
     script = step["run"]
     for expression, value in (
@@ -126,11 +129,19 @@ def test_wheel_smoke_uses_shared_checks_without_importing_the_checkout() -> None
     workflow = yaml.safe_load(WHEEL_WORKFLOW.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["clean_wheel_smoke"]["steps"]
     checkout = next(step for step in steps if step.get("name") == "Checkout release checks")
-    smoke = next(step for step in steps if step.get("name") == "Smoke-test v24 imports and CLI")
+    smoke = next(step for step in steps if step.get("name") == "Smoke-test release imports and CLI")
 
-    assert checkout["with"] == {"ref": "${{ github.sha }}", "path": "source"}
+    assert checkout["uses"] == "./.github/actions/checkout-release-source"
+    assert checkout["with"] == {
+        "source_sha": "${{ inputs.source_sha || github.sha }}",
+        "candidate_sha": "${{ inputs.candidate_sha }}",
+        "source_bundle": "${{ inputs.source_bundle }}",
+        "path": "source",
+    }
     assert smoke["working-directory"] == "${{ runner.temp }}"
-    assert 'python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" --check-cli-help' in smoke["run"]
+    assert smoke["env"]["RELEASE_VERSION"] == "${{ needs.build.outputs.version }}"
+    assert 'python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py"' in smoke["run"]
+    assert '--expected-version "$RELEASE_VERSION" --check-cli-help' in smoke["run"]
     assert "expected_public_api" not in smoke["run"]
     assert "expected_cli_commands" not in smoke["run"]
 
@@ -174,6 +185,34 @@ def test_release_contract_rejects_an_unexpected_package_version(monkeypatch: pyt
 
     with pytest.raises(AssertionError, match="Package version:.*0.0.0"):
         release_contract.check_release_contract()
+
+
+@pytest.mark.parametrize("expected_version", ("25.0.0", "24.1.0", "24.0.1"))
+def test_release_contract_accepts_requested_version_without_installed_metadata(
+    monkeypatch: pytest.MonkeyPatch, expected_version: str
+) -> None:
+    """Source-only service images validate the independently prepared release."""
+    import boxmot
+
+    def missing_metadata(_name: str) -> str:
+        raise release_contract.importlib.metadata.PackageNotFoundError("boxmot")
+
+    monkeypatch.setattr(boxmot, "__version__", expected_version)
+    monkeypatch.setattr(release_contract.importlib.metadata, "version", missing_metadata)
+
+    release_contract.check_release_contract(expected_version=expected_version)
+
+
+def test_release_contract_rejects_mismatched_requested_and_installed_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    import boxmot
+
+    monkeypatch.setattr(boxmot, "__version__", "24.0.1")
+    monkeypatch.setattr(release_contract.importlib.metadata, "version", lambda _name: "24.0.0")
+
+    with pytest.raises(AssertionError, match="Package version:.*24.0.0.*24.0.1"):
+        release_contract.check_release_contract()
+    with pytest.raises(AssertionError, match="Package version:.*25.0.0.*24.0.1"):
+        release_contract.check_release_contract(expected_version="25.0.0")
 
 
 def test_release_cli_help_checks_every_command_and_reports_failures(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 import yaml
+
+from tests.ci import release_contract
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker.yml"
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
+WHEEL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "wheels.yml"
 
 
 def _docker_job() -> dict:
@@ -58,24 +66,134 @@ def test_every_docker_image_checks_the_exact_v24_surface() -> None:
     script = step["run"]
 
     assert "if:" not in step
-    assert 'boxmot.__version__ == "24.0.0"' in script
-    assert "boxmot.__all__ == expected_public_api" in script
-    assert "tuple(boxmot_cli.commands) == expected_cli_commands" in script
-    for command in (
-        "track",
-        "materialize",
-        "eval",
-        "tune",
-        "research",
-        "train-reid",
-        "eval-reid",
-        "compare-reid",
-        "export",
-        "build",
+    assert 'python "${python_args[@]}" < tests/ci/release_contract.py' in script
+    assert "--workdir /tmp" in script
+
+
+@pytest.mark.parametrize("target", ("cli-cpu", "cli-gpu", "service-cpu", "service-gpu"))
+def test_docker_release_smoke_preserves_each_images_import_context(tmp_path: Path, target: str) -> None:
+    """Execute the workflow's Python flags against a source-only package fixture."""
+    step = next(
+        step for step in _docker_job()["steps"] if step.get("name") == "Smoke test v24 package and command surface"
+    )
+    script = step["run"]
+    for expression, value in (
+        ("${{ matrix.target }}", target),
+        ("${{ matrix.repository }}", "boxmot/example"),
+        ("${{ env.VERSION }}", "24.0.0"),
+        ("${{ matrix.tag_suffix }}", ""),
     ):
-        assert f'"{command}"' in script
-    assert 'find_spec("boxmot.api") is None' in script
-    assert 'find_spec("boxmot.data") is None' in script
+        script = script.replace(expression, value)
+
+    source = tmp_path / "service-source"
+    package = source / "boxmot"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("source_only_service = True\n", encoding="utf-8")
+    check = tmp_path / "tests" / "ci" / "release_contract.py"
+    check.parent.mkdir(parents=True)
+    check.write_text(
+        "import sys\nimport boxmot\n"
+        + (
+            "assert sys.flags.isolated == 0\nassert boxmot.source_only_service is True\n"
+            if target.startswith("service-")
+            else "assert sys.flags.isolated == 1\nassert not hasattr(boxmot, 'source_only_service')\n"
+        ),
+        encoding="utf-8",
+    )
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    docker = binaries / "docker"
+    docker.write_text(
+        f"#!{sys.executable}\n"
+        "import os\nimport sys\n"
+        "arguments = sys.argv[sys.argv.index('python') + 1:]\n"
+        "os.execv(sys.executable, [sys.executable, *arguments])\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env={**os.environ, "PATH": f"{binaries}{os.pathsep}{os.environ['PATH']}", "PYTHONPATH": str(source)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_wheel_smoke_uses_shared_checks_without_importing_the_checkout() -> None:
+    workflow = yaml.safe_load(WHEEL_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["clean_wheel_smoke"]["steps"]
+    checkout = next(step for step in steps if step.get("name") == "Checkout release checks")
+    smoke = next(step for step in steps if step.get("name") == "Smoke-test v24 imports and CLI")
+
+    assert checkout["with"] == {"ref": "${{ github.sha }}", "path": "source"}
+    assert smoke["working-directory"] == "${{ runner.temp }}"
+    assert 'python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" --check-cli-help' in smoke["run"]
+    assert "expected_public_api" not in smoke["run"]
+    assert "expected_cli_commands" not in smoke["run"]
+
+
+def test_release_contract_discovers_commands_without_populating_the_lazy_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    from boxmot.engine.cli import boxmot as boxmot_cli
+
+    monkeypatch.setattr(boxmot_cli, "commands", {})
+
+    release_contract.check_release_contract()
+
+    assert boxmot_cli.commands == {}
+
+
+def test_release_contract_rejects_a_missing_time_variant_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    from boxmot.engine.cli import boxmot as boxmot_cli
+
+    monkeypatch.setattr(
+        boxmot_cli,
+        "list_commands",
+        lambda _context: [name for name in release_contract.EXPECTED_CLI_COMMANDS if name != "time-variant"],
+    )
+
+    with pytest.raises(AssertionError, match="CLI commands:.*time-variant"):
+        release_contract.check_release_contract()
+
+
+def test_release_contract_rejects_a_changed_public_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    import boxmot
+
+    monkeypatch.setattr(boxmot, "__all__", (*boxmot.__all__, "UnexpectedExport"))
+
+    with pytest.raises(AssertionError, match="Public API:.*UnexpectedExport"):
+        release_contract.check_release_contract()
+
+
+def test_release_contract_rejects_an_unexpected_package_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    import boxmot
+
+    monkeypatch.setattr(boxmot, "__version__", "0.0.0")
+
+    with pytest.raises(AssertionError, match="Package version:.*0.0.0"):
+        release_contract.check_release_contract()
+
+
+def test_release_cli_help_checks_every_command_and_reports_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def run(arguments: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(arguments)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(release_contract.subprocess, "run", run)
+    release_contract.check_cli_help()
+    assert calls == [["boxmot", name, "--help"] for name in release_contract.EXPECTED_CLI_COMMANDS]
+
+    monkeypatch.setattr(
+        release_contract.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout="", stderr="cannot load adapter"),
+    )
+    with pytest.raises(AssertionError, match="cannot load adapter"):
+        release_contract.check_cli_help()
 
 
 def test_service_gpu_smoke_still_executes_cuda_reid_request() -> None:
@@ -142,12 +260,12 @@ def test_cli_images_package_native_libraries_without_runtime_build_tools() -> No
         assert runtime_library in cli_runtime
 
 
-def test_all_images_smoke_packaged_component_configs() -> None:
-    job = _docker_job()
-    step = next(step for step in job["steps"] if step.get("name") == "Smoke test v24 package and command surface")
-    script = step["run"]
+def test_release_contract_rejects_missing_packaged_configs(monkeypatch: pytest.MonkeyPatch) -> None:
+    import boxmot.engine.experiment_config as experiment_config
 
-    assert "from boxmot.engine.experiment_config import resolve_experiment_config" in script
-    assert 'resolve_experiment_config("mot17/ablation-yolox-lmbn.yaml")' in script
-    assert 'experiment["detector"]["id"] == "yolox-x-mot17"' in script
-    assert 'experiment["reid"]["id"] == "lmbn-n-duke"' in script
+    def missing_config(_name: str) -> dict:
+        raise FileNotFoundError("Packaged experiment is missing")
+
+    monkeypatch.setattr(experiment_config, "resolve_experiment_config", missing_config)
+    with pytest.raises(FileNotFoundError, match="Packaged experiment"):
+        release_contract.check_release_contract()

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -32,10 +33,44 @@ def _docker_stage(name: str) -> str:
     return dockerfile.split(marker, 1)[1].split("\nFROM ", 1)[0]
 
 
-def test_docker_matrix_covers_every_v24_image_with_bounded_jobs() -> None:
-    job = _docker_job()
-    matrix = job["strategy"]["matrix"]["include"]
+def _selected_images(tmp_path: Path, enabled: str | None) -> list[dict]:
+    """Execute the workflow's matrix selection without scheduling any runners."""
+    workflow = yaml.safe_load(DOCKER_WORKFLOW.read_text(encoding="utf-8"))
+    selection = workflow["jobs"]["prepare-matrix"]
+    step = next(step for step in selection["steps"] if step.get("id") == "images")
+    assert selection["runs-on"] == "ubuntu-latest"
+    assert step["env"]["ENABLE_GPU_SERVICE"] == "${{ vars.BOXMOT_GPU_SERVICE_CI }}"
+    env = {key: value for key, value in os.environ.items() if key != "ENABLE_GPU_SERVICE"}
+    if enabled is not None:
+        env["ENABLE_GPU_SERVICE"] = enabled
+    output = tmp_path / "matrix-output"
+    env["GITHUB_OUTPUT"] = str(output)
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", step["run"]],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    name, _, value = output.read_text(encoding="utf-8").strip().partition("=")
+    assert name == "matrix"
+    return json.loads(value)["include"]
 
+
+@pytest.mark.parametrize("enabled", (None, "", "false"))
+def test_docker_defaults_schedule_only_available_hosted_runners(tmp_path: Path, enabled: str | None) -> None:
+    matrix = _selected_images(tmp_path, enabled)
+    assert {entry["target"] for entry in matrix} == {"cli-gpu", "cli-cpu", "service-cpu"}
+    assert {entry["runner"] for entry in matrix} == {"ubuntu-latest"}
+
+
+def test_enabled_gpu_matrix_covers_every_image_with_bounded_jobs(tmp_path: Path) -> None:
+    job = _docker_job()
+    matrix = _selected_images(tmp_path, "true")
+
+    assert job["needs"] == "prepare-matrix"
+    assert job["strategy"]["matrix"] == "${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}"
     assert job["timeout-minutes"] == "${{ matrix.timeout_minutes }}"
     assert {(entry["target"], entry["repository"], entry["tag_suffix"]) for entry in matrix} == {
         ("cli-gpu", "boxmot/boxmot", ""),

--- a/tests/unit/test_publish_workflow.py
+++ b/tests/unit/test_publish_workflow.py
@@ -1,0 +1,285 @@
+"""Exercise release publication against local Git remotes and package-upload stubs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/publish.yml"
+DESTINATION_STEP = "Check the destination immediately before publication"
+PUBLISH_STEP = "Publish the gated distributions"
+PUSH_STEP = "Push the successful version commit and tag"
+RELEASE_STEP = "Create code release at the published commit"
+PYPI_SUCCESS = "${{ success() && inputs.pypi == 'pypi' }}"
+
+
+def _workflow() -> dict:
+    """Load the actual workflow, including shell commands exercised below."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _git(directory: Path, *arguments: str) -> str:
+    """Execute Git only against repositories prepared inside the test directory."""
+    return subprocess.run(
+        ["git", *arguments], cwd=directory, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@dataclass
+class ReleaseRepository:
+    """A candidate checkout, its local origin, and stubbed external publishers."""
+
+    checkout: Path
+    origin: Path
+    log: Path
+    env: dict[str, str]
+
+    def remote_ref(self, ref: str) -> str:
+        """Return an advertised remote ref, or an empty string when it is absent."""
+        output = _git(self.checkout, "ls-remote", "origin", ref)
+        return output.split()[0] if output else ""
+
+    def events(self) -> list[dict]:
+        """Read calls recorded by the publish, push, and release executables."""
+        return [json.loads(line) for line in self.log.read_text().splitlines()] if self.log.exists() else []
+
+    def run_publication(self) -> list[subprocess.CompletedProcess[str]]:
+        """Run real workflow shell steps with GitHub's success and target gating."""
+        steps = _workflow()["jobs"]["pypi-upload"]["steps"]
+        start = next(index for index, step in enumerate(steps) if step["name"] == DESTINATION_STEP)
+        results = []
+        for step in steps[start:]:
+            if condition := step.get("if"):
+                assert condition == PYPI_SUCCESS
+                if self.env["TARGET_REPOSITORY"] != "pypi":
+                    continue
+            result = subprocess.run(
+                ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", step["run"]],
+                cwd=self.checkout,
+                env=self.env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            results.append(result)
+            if result.returncode:
+                break
+        return results
+
+
+@pytest.fixture
+def release_repo(tmp_path: Path) -> ReleaseRepository:
+    """Create an unpublished version commit and intercept all nonlocal actions."""
+    origin = tmp_path / "origin.git"
+    checkout = tmp_path / "candidate"
+    _git(tmp_path, "init", "--bare", "--initial-branch=master", str(origin))
+    _git(tmp_path, "clone", str(origin), str(checkout))
+    _git(checkout, "config", "user.email", "release-test@example.invalid")
+    _git(checkout, "config", "user.name", "Release test")
+    _git(checkout, "config", "commit.gpgsign", "false")
+    (checkout / "version.txt").write_text("24.0.0\n")
+    _git(checkout, "add", "version.txt")
+    _git(checkout, "commit", "-m", "base")
+    _git(checkout, "push", "origin", "HEAD:refs/heads/master")
+    base_sha = _git(checkout, "rev-parse", "HEAD")
+    (checkout / "version.txt").write_text("24.0.1\n")
+    _git(checkout, "commit", "-am", "candidate")
+    candidate_sha = _git(checkout, "rev-parse", "HEAD")
+    _git(checkout, "checkout", "-b", "concurrent", base_sha)
+    (checkout / "concurrent.txt").write_text("An unrelated branch update.\n")
+    _git(checkout, "add", "concurrent.txt")
+    _git(checkout, "commit", "-m", "concurrent change")
+    race_sha = _git(checkout, "rev-parse", "HEAD")
+    _git(checkout, "checkout", "--detach", candidate_sha)
+    (checkout / "dist").mkdir()
+    (checkout / "dist/boxmot-24.0.1-py3-none-any.whl").touch()
+    (checkout / "dist/boxmot-24.0.1.tar.gz").touch()
+
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    stub = f"#!{sys.executable}\n" + '''\
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+command = Path(sys.argv[0]).name
+arguments = sys.argv[1:]
+real_git = os.environ["REAL_GIT"]
+if command != "git" or arguments[0] == "push":
+    with open(os.environ["RELEASE_TEST_LOG"], "a") as log:
+        log.write(json.dumps({"command": command, "arguments": arguments}) + "\\n")
+if command == "git":
+    os.execv(real_git, [real_git, *arguments])
+elif command == "uv":
+    if os.environ.get("FAIL_PUBLICATION"):
+        print("Simulated package-upload failure", file=sys.stderr)
+        sys.exit(1)
+    if os.environ.get("RACE_DURING_PUBLICATION"):
+        subprocess.run(
+            [real_git, "push", "origin", os.environ["RACE_SHA"] + ":refs/heads/master"],
+            check=True,
+        )
+elif command == "gh":
+    tag = "refs/tags/" + arguments[2]
+    published_tag = subprocess.check_output([real_git, "ls-remote", "origin", tag], text=True)
+    assert published_tag.split()[0] == os.environ["CANDIDATE_SHA"], published_tag
+else:
+    raise AssertionError(command)
+'''
+    for name in ("git", "uv", "gh"):
+        executable = binaries / name
+        executable.write_text(stub, encoding="utf-8")
+        executable.chmod(0o755)
+    log = tmp_path / "events.jsonl"
+    real_git = shutil.which("git")
+    assert real_git is not None
+    env = {
+        **os.environ,
+        "PATH": f"{binaries}{os.pathsep}{os.environ['PATH']}",
+        "REAL_GIT": real_git,
+        "RELEASE_TEST_LOG": str(log),
+        "BASE_SHA": base_sha,
+        "CANDIDATE_SHA": candidate_sha,
+        "RACE_SHA": race_sha,
+        "SOURCE_BRANCH": "master",
+        "RELEASE_VERSION": "24.0.1",
+        "TARGET_REPOSITORY": "pypi",
+        "RELEASE_TOKEN": "test-release-token",
+        "PYPI_TOKEN": "test-pypi-token",
+        "TEST_PYPI_TOKEN": "test-testpypi-token",
+    }
+    return ReleaseRepository(checkout, origin, log, env)
+
+
+def test_release_dispatch_and_gates_share_one_unpublished_candidate() -> None:
+    workflow = _workflow()
+    triggers = workflow.get("on", workflow.get(True))
+    assert set(triggers) == {"workflow_dispatch"}
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["bump_type"]["options"] == ["patch", "minor", "major"]
+    assert inputs["bump_type"]["default"] == "patch"
+    assert inputs["pypi"]["options"] == ["pypi", "testpypi"]
+    assert workflow["concurrency"] == {
+        "group": "pypi-release-${{ inputs.pypi }}",
+        "cancel-in-progress": False,
+    }
+
+    jobs = workflow["jobs"]
+    assert jobs["release-gates"]["needs"] == "prepare-release"
+    assert set(jobs["docker-gates"]["needs"]) == {"prepare-release", "release-gates"}
+    assert set(jobs["pypi-upload"]["needs"]) == {"prepare-release", "release-gates", "docker-gates"}
+    candidate_sha = "${{ needs.prepare-release.outputs.candidate_sha }}"
+    assert jobs["release-gates"]["with"]["candidate_sha"] == candidate_sha
+    assert jobs["docker-gates"]["with"]["source_ref"] == candidate_sha
+    assert jobs["docker-gates"]["with"]["push_images"] is False
+    assert jobs["pypi-upload"]["env"]["CANDIDATE_SHA"] == candidate_sha
+    steps = jobs["pypi-upload"]["steps"]
+    assert [step["name"] for step in steps[-4:]] == [DESTINATION_STEP, PUBLISH_STEP, PUSH_STEP, RELEASE_STEP]
+    assert all(step["if"] == PYPI_SUCCESS for step in steps[-2:])
+    assert all("git push" not in step.get("run", "") for step in jobs["prepare-release"]["steps"])
+
+
+def test_successful_pypi_upload_precedes_atomic_commit_tag_push_and_release(release_repo: ReleaseRepository) -> None:
+    assert release_repo.remote_ref("refs/heads/master") == release_repo.env["BASE_SHA"]
+    results = release_repo.run_publication()
+
+    assert len(results) == 4
+    assert all(result.returncode == 0 for result in results), results
+    assert release_repo.remote_ref("refs/heads/master") == release_repo.env["CANDIDATE_SHA"]
+    assert release_repo.remote_ref("refs/tags/v24.0.1") == release_repo.env["CANDIDATE_SHA"]
+    events = release_repo.events()
+    assert [event["command"] for event in events] == ["uv", "git", "gh"]
+    assert events[0]["arguments"] == [
+        "publish", "dist/boxmot-24.0.1-py3-none-any.whl", "dist/boxmot-24.0.1.tar.gz"
+    ]
+    assert events[1]["arguments"] == [
+        "push", "--atomic", "origin", f"{release_repo.env['CANDIDATE_SHA']}:refs/heads/master", "refs/tags/v24.0.1"
+    ]
+    assert events[2]["arguments"][:4] == ["release", "create", "v24.0.1", "--verify-tag"]
+
+
+def test_testpypi_upload_does_not_change_branch_tag_or_create_release(release_repo: ReleaseRepository) -> None:
+    release_repo.env["TARGET_REPOSITORY"] = "testpypi"
+    release_repo.env["RELEASE_TOKEN"] = ""
+    results = release_repo.run_publication()
+
+    assert len(results) == 2
+    assert all(result.returncode == 0 for result in results), results
+    assert release_repo.remote_ref("refs/heads/master") == release_repo.env["BASE_SHA"]
+    assert release_repo.remote_ref("refs/tags/v24.0.1") == ""
+    assert release_repo.events() == [{
+        "command": "uv",
+        "arguments": [
+            "publish", "--index", "testpypi", "dist/boxmot-24.0.1-py3-none-any.whl", "dist/boxmot-24.0.1.tar.gz"
+        ],
+    }]
+
+
+def test_failed_upload_leaves_branch_and_tag_unchanged(release_repo: ReleaseRepository) -> None:
+    release_repo.env["FAIL_PUBLICATION"] = "1"
+    results = release_repo.run_publication()
+
+    assert len(results) == 2
+    assert results[-1].returncode != 0
+    assert "Simulated package-upload failure" in results[-1].stderr
+    assert [event["command"] for event in release_repo.events()] == ["uv"]
+    assert release_repo.remote_ref("refs/heads/master") == release_repo.env["BASE_SHA"]
+    assert release_repo.remote_ref("refs/tags/v24.0.1") == ""
+
+
+@pytest.mark.parametrize("obstruction", ("branch-moved", "existing-tag", "missing-token"))
+def test_unready_destination_is_rejected_before_upload(release_repo: ReleaseRepository, obstruction: str) -> None:
+    expected_branch = release_repo.env["BASE_SHA"]
+    expected_tag = ""
+    if obstruction == "branch-moved":
+        _git(release_repo.checkout, "push", "origin", f"{release_repo.env['RACE_SHA']}:refs/heads/master")
+        expected_branch = release_repo.env["RACE_SHA"]
+    elif obstruction == "existing-tag":
+        _git(release_repo.checkout, "push", "origin", f"{expected_branch}:refs/tags/v24.0.1")
+        expected_tag = expected_branch
+    else:
+        release_repo.env["RELEASE_TOKEN"] = ""
+
+    results = release_repo.run_publication()
+
+    assert len(results) == 1
+    assert results[0].returncode != 0
+    assert release_repo.events() == []
+    assert release_repo.remote_ref("refs/heads/master") == expected_branch
+    assert release_repo.remote_ref("refs/tags/v24.0.1") == expected_tag
+
+
+@pytest.mark.parametrize("obstruction", ("branch-race", "rejected-push"))
+def test_push_failure_after_upload_preserves_remote_and_reports_recovery(
+    release_repo: ReleaseRepository, obstruction: str
+) -> None:
+    expected_branch = release_repo.env["BASE_SHA"]
+    if obstruction == "branch-race":
+        release_repo.env["RACE_DURING_PUBLICATION"] = "1"
+        expected_branch = release_repo.env["RACE_SHA"]
+    else:
+        hook = release_repo.origin / "hooks/pre-receive"
+        hook.write_text("#!/bin/sh\necho 'Repository policy rejected release push' >&2\nexit 1\n")
+        hook.chmod(0o755)
+
+    results = release_repo.run_publication()
+
+    assert len(results) == 3
+    assert results[-1].returncode != 0
+    assert "PyPI publication succeeded" in results[-1].stdout
+    assert "Recover the tested candidate from the release-source artifact" in results[-1].stdout
+    assert "do not rebuild or force-push" in results[-1].stdout
+    assert [event["command"] for event in release_repo.events()] == ["uv", "git"]
+    assert release_repo.remote_ref("refs/heads/master") == expected_branch
+    assert release_repo.remote_ref("refs/tags/v24.0.1") == ""

--- a/tests/unit/test_release_source_checkout.py
+++ b/tests/unit/test_release_source_checkout.py
@@ -1,0 +1,183 @@
+"""Exercise unpublished release checkout using real local Git bundles."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTION_PATH = REPO_ROOT / ".github/actions/checkout-release-source/action.yml"
+
+
+def _action() -> dict:
+    """Load the same action scripts executed by the reusable release gates."""
+    return yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
+
+
+def _git(path: Path, *arguments: str) -> str:
+    """Run Git in an isolated fixture repository."""
+    return subprocess.run(["git", *arguments], cwd=path, capture_output=True, text=True, check=True).stdout.strip()
+
+
+@pytest.fixture
+def candidate(tmp_path: Path) -> SimpleNamespace:
+    """Clone the published base before preparing an unpushed candidate commit."""
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init", "-b", "main")
+    _git(source, "config", "user.name", "Release Test")
+    _git(source, "config", "user.email", "release-test@example.invalid")
+    _git(source, "config", "commit.gpgsign", "false")
+    _git(source, "config", "core.hooksPath", "/dev/null")
+    (source / "version.txt").write_text("24.0.0\n", encoding="utf-8")
+    _git(source, "add", "version.txt")
+    _git(source, "commit", "-m", "base")
+    base_sha = _git(source, "rev-parse", "HEAD")
+    checkout = tmp_path / "checkout with spaces"
+    _git(tmp_path, "clone", "--no-local", str(source), str(checkout))
+
+    _git(source, "checkout", "-b", "release-candidate")
+    (source / "version.txt").write_text("24.0.1\n", encoding="utf-8")
+    _git(source, "commit", "-am", "release candidate")
+    candidate_sha = _git(source, "rev-parse", "HEAD")
+    bundle = tmp_path / "bundle with spaces"
+    bundle.mkdir()
+    _git(source, "bundle", "create", str(bundle / "release-source.bundle"), "release-candidate", f"^{base_sha}")
+    return SimpleNamespace(source=source, checkout=checkout, base=base_sha, sha=candidate_sha, bundle=bundle)
+
+
+def _select_source(
+    candidate: SimpleNamespace, *, expected: str | None = None, bundle: bool = True
+) -> subprocess.CompletedProcess:
+    """Execute the composite's actual selection script with GitHub's Bash flags."""
+    step = next(step for step in _action()["runs"]["steps"] if step.get("id") == "source")
+    return subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", step["run"]],
+        cwd=candidate.checkout,
+        env={
+            **os.environ,
+            "CANDIDATE_SHA": (candidate.sha if expected is None else expected) if bundle else "",
+            "BUNDLE_DIRECTORY": str(candidate.bundle) if bundle else "",
+            "GITHUB_OUTPUT": str(candidate.checkout.parent / "source-output"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_candidate_bundle_checks_out_the_exact_unpublished_commit(candidate: SimpleNamespace) -> None:
+    missing = subprocess.run(
+        ["git", "cat-file", "-e", candidate.sha], cwd=candidate.checkout, capture_output=True, check=False
+    )
+    assert missing.returncode != 0
+
+    result = _select_source(candidate)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(candidate.checkout, "rev-parse", "HEAD") == candidate.sha
+    assert (candidate.checkout / "version.txt").read_text() == "24.0.1\n"
+    assert _git(candidate.checkout, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
+    assert (candidate.checkout.parent / "source-output").read_text() == f"sha={candidate.sha}\n"
+    assert _git(candidate.checkout, "rev-parse", "origin/main") == candidate.base
+
+
+def test_standalone_checkout_keeps_the_published_revision(candidate: SimpleNamespace) -> None:
+    result = _select_source(candidate, bundle=False)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(candidate.checkout, "rev-parse", "HEAD") == candidate.base
+    assert (candidate.checkout / "version.txt").read_text() == "24.0.0\n"
+
+
+def test_candidate_bundle_rejects_a_different_commit_before_checkout(candidate: SimpleNamespace) -> None:
+    result = _select_source(candidate, expected=candidate.base)
+
+    assert result.returncode != 0
+    assert f"expected {candidate.base}" in result.stderr
+    assert _git(candidate.checkout, "rev-parse", "HEAD") == candidate.base
+
+
+def test_candidate_bundle_rejects_an_unrelated_history(candidate: SimpleNamespace) -> None:
+    _git(candidate.source, "checkout", "--orphan", "unrelated")
+    _git(candidate.source, "commit", "-m", "unrelated source")
+    candidate.sha = _git(candidate.source, "rev-parse", "HEAD")
+    _git(candidate.source, "update-ref", "refs/heads/release-candidate", candidate.sha)
+    _git(candidate.source, "bundle", "create", str(candidate.bundle / "release-source.bundle"), "release-candidate")
+
+    result = _select_source(candidate)
+
+    assert result.returncode != 0
+    assert "does not descend from base" in result.stderr
+    assert _git(candidate.checkout, "rev-parse", "HEAD") == candidate.base
+
+
+@pytest.mark.parametrize(("candidate_sha", "artifact"), (("abc", ""), ("", "release-source")))
+def test_candidate_inputs_must_be_supplied_together(candidate_sha: str, artifact: str) -> None:
+    step = next(step for step in _action()["runs"]["steps"] if step.get("name") == "Validate candidate inputs")
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", step["run"]],
+        env={**os.environ, "CANDIDATE_SHA": candidate_sha, "SOURCE_BUNDLE": artifact},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "must be supplied together" in result.stderr
+
+
+def test_checkout_action_keeps_credentials_and_downloads_outside_the_source_tree() -> None:
+    action = _action()
+    checkout = next(step for step in action["runs"]["steps"] if step.get("uses") == "actions/checkout@v4")
+    allocation = next(step for step in action["runs"]["steps"] if step.get("id") == "bundle-directory")
+    download = next(step for step in action["runs"]["steps"] if step.get("uses") == "actions/download-artifact@v4")
+
+    assert action["inputs"]["token"]["default"] == "${{ github.token }}"
+    assert checkout["with"] == {
+        "ref": "${{ inputs.source_sha }}",
+        "fetch-depth": 0,
+        "path": "${{ inputs.path }}",
+        "token": "${{ inputs.token }}",
+    }
+    assert 'mktemp -d "$RUNNER_TEMP/boxmot-release-source.XXXXXX"' in allocation["run"]
+    assert download["with"] == {
+        "name": "${{ inputs.source_bundle }}",
+        "path": "${{ steps.bundle-directory.outputs.path }}",
+    }
+
+
+def test_reusable_wheel_jobs_all_select_the_same_candidate_source() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/wheels.yml").read_text())
+    for job in ("source_gates", "build", "clean_wheel_smoke"):
+        steps = workflow["jobs"][job]["steps"]
+        assert steps[0]["uses"] == "actions/checkout@v4"
+        assert steps[0]["with"]["ref"] == "${{ github.workflow_sha }}"
+        selection = steps[1]
+        assert selection["uses"] == "./.github/actions/checkout-release-source"
+        assert selection["with"]["source_sha"] == "${{ inputs.source_sha || github.sha }}"
+        assert selection["with"]["candidate_sha"] == "${{ inputs.candidate_sha }}"
+        assert selection["with"]["source_bundle"] == "${{ inputs.source_bundle }}"
+    build_script = next(
+        step["run"] for step in workflow["jobs"]["build"]["steps"] if step.get("id") == "release-version"
+    )
+    assert 'metadata["Version"] == version' in build_script
+    assert "module_version == version" in build_script
+    assert "24.0.0" not in build_script
+
+
+def test_reusable_docker_job_selects_candidate_or_published_source() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/docker.yml").read_text())
+    steps = workflow["jobs"]["build-and-push"]["steps"]
+    assert steps[0]["uses"] == "actions/checkout@v4"
+    assert steps[0]["with"]["ref"] == "${{ github.workflow_sha }}"
+    assert steps[1]["uses"] == "./.github/actions/checkout-release-source"
+    assert steps[1]["with"] == {
+        "source_sha": "${{ inputs.source_base || inputs.source_ref || github.event.release.tag_name }}",
+        "candidate_sha": "${{ inputs.source_bundle && inputs.source_ref || '' }}",
+        "source_bundle": "${{ inputs.source_bundle }}",
+    }

--- a/tests/unit/test_release_source_checkout.py
+++ b/tests/unit/test_release_source_checkout.py
@@ -157,7 +157,7 @@ def test_reusable_wheel_jobs_all_select_the_same_candidate_source() -> None:
         steps = workflow["jobs"][job]["steps"]
         assert steps[0]["uses"] == "actions/checkout@v4"
         assert steps[0]["with"]["ref"] == "${{ github.workflow_sha }}"
-        selection = steps[1]
+        selection = next(step for step in steps if step.get("uses") == "./.github/actions/checkout-release-source")
         assert selection["uses"] == "./.github/actions/checkout-release-source"
         assert selection["with"]["source_sha"] == "${{ inputs.source_sha || github.sha }}"
         assert selection["with"]["candidate_sha"] == "${{ inputs.candidate_sha }}"

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -1,0 +1,201 @@
+"""Exercise release preparation with an isolated Git project and offline uv."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+tomllib = pytest.importorskip("tomllib", reason="Release preparation uses Python 3.11 or newer.")
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github/scripts/bump_release.py"
+SPEC = importlib.util.spec_from_file_location("bump_release", SCRIPT)
+release_version = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_version)
+
+
+def _run(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    """Run a fixture-only command with actionable captured output on failure."""
+    return subprocess.run(arguments, cwd=root, check=True, capture_output=True, text=True)
+
+
+def _commit(root: Path) -> None:
+    """Record fixture inputs without configuring the user's Git identity."""
+    _run(root, "git", "add", ".")
+    _run(
+        root,
+        "git",
+        "-c",
+        "user.name=Release Test",
+        "-c",
+        "user.email=release@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+    )
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Create a dependency-free editable package using the repository's pinned uv."""
+    if shutil.which("uv") is None:
+        pytest.skip("Release bump integration checks require uv 0.12.4.")
+    root = tmp_path / "project"
+    root.mkdir()
+    monkeypatch.setenv("UV_OFFLINE", "1")
+    monkeypatch.setenv("UV_PYTHON", sys.executable)
+    monkeypatch.setenv("UV_PYTHON_DOWNLOADS", "never")
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "uv-cache"))
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(tmp_path / "unused-venv"))
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "boxmot"\nversion = "1.2.3"\nrequires-python = ">=3.11"\n'
+        'dependencies = []\n\n[build-system]\nrequires = ["setuptools"]\nbuild-backend = "setuptools.build_meta"\n'
+        '\n[tool.uv]\nrequired-version = "==0.12.4"\n',
+        encoding="utf-8",
+    )
+    (root / "boxmot").mkdir()
+    (root / "boxmot/__init__.py").write_text(
+        '"""Fixture package."""\n__version__ = "1.2.3"\nUNCHANGED = "1.2.3"\n', encoding="utf-8"
+    )
+    (root / "README.md").write_text("Release fixture.\n", encoding="utf-8")
+    _run(root, "uv", "lock")
+    _run(root, "git", "init")
+    _commit(root)
+    yield root
+    assert not (tmp_path / "unused-venv").exists(), "Version preparation must never sync an environment."
+    assert not (root / ".venv").exists()
+
+
+@pytest.mark.parametrize("kind,expected", (("major", "2.0.0"), ("minor", "1.3.0"), ("patch", "1.2.4")))
+def test_bumps_project_runtime_and_lock_without_syncing(project: Path, kind: str, expected: str) -> None:
+    before = (project / "boxmot/__init__.py").read_text(encoding="utf-8")
+
+    assert release_version.bump_release(project, kind) == ("1.2.3", expected)
+
+    metadata = tomllib.loads((project / "pyproject.toml").read_text(encoding="utf-8"))
+    lock = tomllib.loads((project / "uv.lock").read_text(encoding="utf-8"))
+    assert metadata["project"]["version"] == lock["package"][0]["version"] == expected
+    assert lock["package"][0]["source"] == {"editable": "."}
+    assert (project / "boxmot/__init__.py").read_text(encoding="utf-8") == before.replace(
+        '__version__ = "1.2.3"', f'__version__ = "{expected}"'
+    )
+    assert set(_run(project, "git", "diff", "--name-only").stdout.splitlines()) == release_version.VERSION_FILES
+
+
+def test_replaces_only_ast_value_with_unicode_and_inline_comment(project: Path) -> None:
+    source = '"""Non-ASCII: 🎯."""\nmarker = "🎯"; __version__ = "1.2.3"  # keep this\nOTHER = "1.2.3"\n'
+    (project / "boxmot/__init__.py").write_text(source, encoding="utf-8")
+    _commit(project)
+
+    release_version.bump_release(project, "patch")
+
+    assert (project / "boxmot/__init__.py").read_text(encoding="utf-8") == source.replace(
+        '__version__ = "1.2.3"', '__version__ = "1.2.4"'
+    )
+
+
+@pytest.mark.parametrize("filename", ("pyproject.toml", "boxmot/__init__.py", "uv.lock"))
+def test_rejects_disagreeing_versions_before_running_uv(project: Path, filename: str) -> None:
+    path = project / filename
+    path.write_text(path.read_text(encoding="utf-8").replace('"1.2.3"', '"1.2.2"'), encoding="utf-8")
+    _commit(project)
+
+    with pytest.raises(ValueError, match="versions must agree"):
+        release_version.bump_release(project, "patch")
+
+    assert not _run(project, "git", "status", "--porcelain").stdout
+
+
+@pytest.mark.parametrize("version", ("1.2", "1.2.3rc1", "01.2.3"))
+def test_rejects_nonstable_or_malformed_versions(project: Path, version: str) -> None:
+    for filename in release_version.VERSION_FILES:
+        path = project / filename
+        path.write_text(path.read_text(encoding="utf-8").replace('"1.2.3"', f'"{version}"'), encoding="utf-8")
+    _commit(project)
+
+    with pytest.raises(ValueError, match="stable major.minor.patch"):
+        release_version.bump_release(project, "patch")
+
+    assert not _run(project, "git", "status", "--porcelain").stdout
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    (
+        '__version__ = "1.2.3"\n__version__ = "1.2.3"\n',
+        '__version__ = "1.2.3"\n__version__ += ".post1"\n',
+        "__version__ = get_version()\n",
+    ),
+)
+def test_rejects_ambiguous_or_computed_runtime_version(project: Path, assignment: str) -> None:
+    (project / "boxmot/__init__.py").write_text(assignment, encoding="utf-8")
+    _commit(project)
+
+    with pytest.raises(ValueError, match="__version__ assignment"):
+        release_version.bump_release(project, "patch")
+
+
+def test_rejects_a_noneditable_lock_record(project: Path) -> None:
+    path = project / "uv.lock"
+    path.write_text(path.read_text(encoding="utf-8").replace('editable = "."', 'virtual = "."'), encoding="utf-8")
+    _commit(project)
+
+    with pytest.raises(ValueError, match="local editable boxmot"):
+        release_version.bump_release(project, "patch")
+
+
+def test_rejects_unknown_bump_and_dirty_checkout(project: Path) -> None:
+    with pytest.raises(ValueError, match="Unknown release bump"):
+        release_version.bump_release(project, "rc")
+    (project / "README.md").write_text("Uncommitted changes.\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="clean checkout"):
+        release_version.bump_release(project, "patch")
+
+
+def test_rejects_unexpected_files_changed_by_uv(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run = subprocess.run
+
+    def unexpected_change(arguments: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        result = run(arguments, **kwargs)
+        if arguments[:2] == ["uv", "version"]:
+            (project / "unexpected.txt").write_text("Unexpected generated output.\n", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(release_version.subprocess, "run", unexpected_change)
+    with pytest.raises(ValueError, match="must change only.*unexpected.txt"):
+        release_version.bump_release(project, "patch")
+
+
+def test_rejects_a_lock_version_left_stale_by_uv(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run = subprocess.run
+    original_lock = (project / "uv.lock").read_bytes()
+
+    def stale_lock(arguments: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        result = run(arguments, **kwargs)
+        if arguments[:2] == ["uv", "version"]:
+            (project / "uv.lock").write_bytes(original_lock)
+        return result
+
+    monkeypatch.setattr(release_version.subprocess, "run", stale_lock)
+    with pytest.raises(ValueError, match="versions must agree"):
+        release_version.bump_release(project, "patch")
+
+
+def test_cli_emits_versions_for_github_actions(project: Path, tmp_path: Path) -> None:
+    output = tmp_path / "github-output"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--bump", "minor"],
+        cwd=project,
+        env={**os.environ, "GITHUB_OUTPUT": str(output)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert output.read_text(encoding="utf-8") == "old_version=1.2.3\nversion=1.3.0\n"
+    assert "Prepared BoxMOT 1.2.3 -> 1.3.0" in result.stdout

--- a/tests/unit/test_ubuntu_packages.py
+++ b/tests/unit/test_ubuntu_packages.py
@@ -1,0 +1,149 @@
+"""Execute the CI APT setup without modifying the host's package sources."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTION = "./.github/actions/install-ubuntu-packages"
+
+
+@pytest.fixture
+def apt_host(tmp_path: Path) -> SimpleNamespace:
+    """Record package-manager calls while retaining an unrelated vendor source."""
+    sources = tmp_path / "etc with spaces/apt"
+    source_parts = sources / "sources.list.d"
+    source_parts.mkdir(parents=True)
+    (source_parts / "google-chrome.list").write_text("deb https://dl.google.com/linux/chrome/deb/ stable main\n")
+    binary_dir = tmp_path / "bin"
+    binary_dir.mkdir()
+    sudo = binary_dir / "sudo"
+    sudo.write_text('#!/bin/bash\nexec "$@"\n')
+    sudo.chmod(0o755)
+    apt = binary_dir / "apt-get"
+    apt.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "with Path(os.environ['APT_CALLS']).open('a') as log:\n"
+        "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "operation = 'update' if 'update' in sys.argv else 'install'\n"
+        "sys.exit(int(os.environ.get('APT_FAIL_' + operation.upper(), '0')))\n"
+    )
+    apt.chmod(0o755)
+    return SimpleNamespace(sources=sources, binary_dir=binary_dir, calls=tmp_path / "calls.jsonl")
+
+
+def _run_setup(host: SimpleNamespace, packages: str = "cmake g++ libopencv-dev libeigen3-dev", **env: str) -> tuple:
+    """Run the actual composite-action script with isolated sources and binaries."""
+    action = yaml.safe_load((REPO_ROOT / ACTION / "action.yml").read_text())
+    step = action["runs"]["steps"][0]
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", step["run"]],
+        env={
+            **os.environ,
+            "PATH": f"{host.binary_dir}{os.pathsep}{os.environ['PATH']}",
+            "APT_ETC": str(host.sources),
+            "PACKAGES": packages,
+            "APT_CALLS": str(host.calls),
+            **env,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    calls = [json.loads(line) for line in host.calls.read_text().splitlines()] if host.calls.exists() else []
+    return result, calls
+
+
+@pytest.mark.parametrize("source_file", ("sources.list.d/ubuntu.sources", "sources.list"))
+@pytest.mark.parametrize("packages", ("cmake g++ libopencv-dev libeigen3-dev", "jq\ncmake"))
+def test_update_and_install_use_only_ubuntu_sources(apt_host: SimpleNamespace, source_file: str, packages: str) -> None:
+    ubuntu = apt_host.sources / source_file
+    ubuntu.write_text("Ubuntu source fixture\n")
+    if source_file.endswith(".sources"):
+        # Newer runners must prefer Deb822 even when a legacy file exists.
+        (apt_host.sources / "sources.list").write_text("Legacy source fixture\n")
+    original_sources = {path: path.read_bytes() for path in apt_host.sources.rglob("*") if path.is_file()}
+
+    result, calls = _run_setup(apt_host, packages)
+
+    assert result.returncode == 0, result.stderr
+    assert len(calls) == 2
+    options = calls[0][:-1]
+    assert calls[0][-1] == "update"
+    assert calls[1] == [*options, "install", "--yes", "--", *packages.split()]
+    assert options[::2] == ["-o"] * 5
+    assert set(options[1::2]) == {
+        f"Dir::Etc::sourcelist={ubuntu}",
+        "Dir::Etc::sourceparts=/dev/null",
+        "APT::Get::List-Cleanup=0",
+        "APT::Update::Error-Mode=any",
+        "Acquire::Retries=3",
+    }
+    assert {path: path.read_bytes() for path in apt_host.sources.rglob("*") if path.is_file()} == original_sources
+
+
+@pytest.mark.parametrize(("operation", "call_count"), (("UPDATE", 1), ("INSTALL", 2)))
+def test_package_errors_fail_the_step(apt_host: SimpleNamespace, operation: str, call_count: int) -> None:
+    (apt_host.sources / "sources.list").write_text("Ubuntu source fixture\n")
+
+    result, calls = _run_setup(apt_host, **{f"APT_FAIL_{operation}": "100"})
+
+    assert result.returncode == 100
+    assert len(calls) == call_count
+
+
+def test_missing_ubuntu_sources_fail_before_invoking_apt(apt_host: SimpleNamespace) -> None:
+    (apt_host.sources / "sources.list.d/ubuntu.sources").touch()
+    (apt_host.sources / "sources.list").touch()
+
+    result, calls = _run_setup(apt_host)
+
+    assert result.returncode != 0
+    assert "No Ubuntu APT source file found" in result.stderr
+    assert calls == []
+
+
+def test_empty_packages_fail_before_invoking_apt(apt_host: SimpleNamespace) -> None:
+    (apt_host.sources / "sources.list").write_text("Ubuntu source fixture\n")
+
+    result, calls = _run_setup(apt_host, " \n ")
+
+    assert result.returncode != 0
+    assert "At least one Ubuntu package is required" in result.stderr
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name", "packages"),
+    (
+        ("ci", "native_build", "cmake g++ libopencv-dev libeigen3-dev"),
+        ("ci", "cpp_trackers", "cmake g++ libopencv-dev libeigen3-dev"),
+        ("ci", "metrics", "jq"),
+        ("wheels", "source_gates", "cmake g++ libopencv-dev libeigen3-dev"),
+        ("benchmark", "mot-metrics-benchmark", "cmake g++ libopencv-dev libeigen3-dev"),
+    ),
+)
+def test_ubuntu_jobs_use_the_shared_installer(workflow_name: str, job_name: str, packages: str) -> None:
+    workflow = yaml.safe_load((REPO_ROOT / f".github/workflows/{workflow_name}.yml").read_text())
+    steps = workflow["jobs"][job_name]["steps"]
+    installer = next(step for step in steps if step.get("uses") == ACTION)
+
+    assert installer["with"]["packages"] == packages
+    assert not any("apt-get" in step.get("run", "") for step in steps)
+    if job_name == "cpp_trackers":
+        assert installer["if"] == "runner.os == 'Linux'"
+    if job_name == "source_gates":
+        source_checkout = next(
+            step for step in steps if step.get("uses") == "./.github/actions/checkout-release-source"
+        )
+        assert steps.index(installer) < steps.index(source_checkout)


### PR DESCRIPTION
Release validation failed when CLI builders loaded native tracker libraries without OpenCV runtime dependencies, and the package smoke read Click's initially empty command cache against a stale command list. The publish workflow also lost its selected version bump and repository writeback.

The workflow now offers `patch` (default), `minor`, and `major`. Preparation synchronizes `pyproject.toml`, `boxmot/__init__.py`, and `uv.lock`, then preserves one unpublished candidate commit for all source, wheel, and Docker checks. After the checked distributions publish successfully to PyPI, it pushes that exact commit and its version tag atomically and creates the GitHub release. TestPyPI leaves the remote branch, tags, and GitHub releases unchanged. Runs targeting the same package repository are serialized, and a branch that moves during validation stops publication.

CLI builders now install their OpenCV runtime dependencies before native loading checks. Docker, wheel, and Python API checks share explicit API/CLI expectations, discover lazy commands through `list_commands()`, include `time-variant`, and validate the requested version instead of pinning 24.0.0. CLI checks retain isolated imports; service checks retain their source installation's required `PYTHONPATH`. The default image matrix contains only `cli-gpu`, `cli-cpu`, and `service-cpu`, all on GitHub-hosted runners. Set the repository Actions variable `BOXMOT_GPU_SERVICE_CI=true` to enable the complete `service-gpu` build, validation, and publication once a `gpu-latest` runner is available.

Ubuntu dependency setup now uses a shared action for native builds, C++ tracker smoke tests, wheel gates, benchmarks, and metric reporting. Both APT commands read only the runner's Ubuntu sources, preventing unrelated Chrome repository hash mismatches from stopping these jobs. Hash and signature verification remain enabled, downloads retry up to three times, and Ubuntu repository errors still fail the job. The wheel gate installs system packages before selecting the release source so older source revisions do not need the new local action.

## Testing

- `.venv/bin/python -m pytest tests/unit/test_ubuntu_packages.py tests/unit/test_ci_workflow_v24.py tests/unit/test_release_source_checkout.py -q` — **34 passed**. Executes the actual APT action with stubbed host commands; covers Deb822 and legacy sources, unchanged vendor configuration, failure propagation, and workflow ordering.
- `/private/tmp/boxmot-ci-tools/actionlint .github/workflows/ci.yml .github/workflows/wheels.yml .github/workflows/benchmark.yml`, `.venv/bin/ruff check tests/unit/test_ubuntu_packages.py tests/unit/test_release_source_checkout.py`, `git diff --check`, and `.venv/bin/python -m mkdocs build --strict --site-dir /private/tmp/boxmot-ubuntu-apt-docs` — passed. [GitHub CI at 6a8016146](https://github.com/mikel-brostrom/boxmot/actions/runs/34384864407) passed the full `native_build` job and the previously failing Ubuntu `cpp_trackers` dependency installation step. Remaining checks were still running at verification time.

- `.venv/bin/python -m pytest tests/unit/test_docker_workflow_v24.py tests/unit/test_publish_workflow.py tests/unit/test_release_source_checkout.py -q` — **43 passed** after making GPU service optional. The matrix-selection script is executed for unset, empty, false, and true settings.
- `actionlint .github/workflows/docker.yml .github/workflows/publish.yml .github/workflows/wheels.yml` and `.venv/bin/python -m mkdocs build --strict --site-dir /private/tmp/boxmot-optional-gpu-docs` — passed.

- `.venv/bin/python -m pytest tests/unit/test_publish_workflow.py tests/unit/test_release_version.py tests/unit/test_release_source_checkout.py tests/unit/test_docker_workflow_v24.py tests/unit/test_docker_native_runtime.py tests/ci/python_api_smoke.py -q` — **64 passed**. Tests use actual offline uv bumps, real local Git bundles and remotes, and stubbed external publishers. They cover all three bump types, immutable source restoration, TestPyPI isolation, failed uploads, stale branches, existing tags, post-upload races, and rejected pushes.
- An isolated full-repository trial bumped 24.0.0 to 24.1.0 with exactly three one-line changes. `uv build --no-sources --out-dir /private/tmp/boxmot-version-bump-artifacts` built its wheel and source distribution. The actual prepare-step shell produced a valid candidate Git bundle containing only that commit.
- `PATH=/private/tmp/boxmot-release-smoke-venv/bin:$PATH /private/tmp/boxmot-release-smoke-venv/bin/python -I /private/tmp/boxmot-release-fixes/tests/ci/release_contract.py --expected-version 24.1.0 --check-cli-help` — the separately installed trial wheel passed its version/API/configuration checks and help for all 11 commands.
- `.venv/bin/ruff check .github/scripts/bump_release.py tests/ci/release_contract.py tests/ci/python_api_smoke.py tests/unit/test_release_version.py tests/unit/test_release_source_checkout.py tests/unit/test_docker_workflow_v24.py tests/unit/test_publish_workflow.py` and `git diff --check` — passed.
- `actionlint -ignore 'label "gpu-latest" is unknown' .github/workflows/publish.yml .github/workflows/wheels.yml .github/workflows/docker.yml` — passed with the existing custom runner label acknowledged.
- Strict documentation build passed.
- [Docker validation at adc791bd8](https://github.com/mikel-brostrom/boxmot/actions/runs/34378863426) passed `cli-cpu`, `cli-gpu`, and `service-cpu`, including native loading. The later version-bump orchestration is covered by the tests above. The remaining queued GPU service job was canceled; this target is now disabled by default.

## Operational requirements

Real publication requires `RELEASE_PAT` with permission for the normal branch/tag push and GitHub release, plus the selected package-index token. All three default Docker gates require success. A Linux NVIDIA runner is required only when GPU service validation is explicitly enabled. No package or release was published during development.

PyPI upload and Git writeback cannot be one transaction. If publication succeeds but the atomic push fails, the workflow reports the partial success explicitly and retains the exact tested candidate bundle for recovery.
