### PR TITLE
ci: strengthen release checks and cache CPU Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,40 +52,19 @@ on:
     types: [published]
 
 jobs:
-  prepare-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.images.outputs.matrix }}
-    steps:
-      - name: Select images supported by the configured runners
-        id: images
-        env:
-          ENABLE_GPU_SERVICE: ${{ vars.BOXMOT_GPU_SERVICE_CI }}
-        run: |
-          python3 - <<'PY'
-          import json
-          import os
-
-          images = [
-              {"target": "cli-gpu", "repository": "boxmot/boxmot", "tag_suffix": "", "runner": "ubuntu-latest", "timeout_minutes": 90},
-              {"target": "cli-cpu", "repository": "boxmot/boxmot", "tag_suffix": "-cpu", "runner": "ubuntu-latest", "timeout_minutes": 90},
-              {"target": "service-cpu", "repository": "boxmot/boxmot-service", "tag_suffix": "", "runner": "ubuntu-latest", "timeout_minutes": 90},
-              {"target": "service-gpu", "repository": "boxmot/boxmot-service", "tag_suffix": "-gpu", "runner": "gpu-latest", "timeout_minutes": 120},
-          ]
-          if os.environ.get("ENABLE_GPU_SERVICE") != "true":
-              images = [image for image in images if image["target"] != "service-gpu"]
-              print("Skipping service-gpu: BOXMOT_GPU_SERVICE_CI is not enabled.")
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"matrix={json.dumps({'include': images})}\n")
-          PY
-
   build-and-push:
-    needs: prepare-matrix
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.timeout_minutes }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+      matrix:
+        include:
+          - target: cli-cpu
+            repository: boxmot/boxmot
+            tag_suffix: -cpu
+          - target: service-cpu
+            repository: boxmot/boxmot-service
+            tag_suffix: ''
 
     steps:
       # Bootstrap from workflow code, including when manually rebuilding older source.
@@ -177,15 +156,8 @@ jobs:
           docker run --rm ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
             python -c 'import torch; assert torch.version.cuda is None, f"expected a CPU-only PyTorch build, got CUDA {torch.version.cuda!r}"'
 
-      - name: Smoke test GPU CLI image
-        if: matrix.target == 'cli-gpu'
-        run: |
-          docker run --rm ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} boxmot --help
-          docker run --rm ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
-            python -c 'import torch; assert torch.version.cuda == "13.0", f"expected CUDA 13.0 metadata, got {torch.version.cuda!r}"'
-
       - name: Smoke test prebuilt native tracker
-        if: matrix.target == 'cli-cpu' || matrix.target == 'cli-gpu'
+        if: matrix.target == 'cli-cpu'
         run: |
           docker run --rm --interactive --workdir /tmp \
             ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
@@ -277,150 +249,9 @@ jobs:
             --data '{"frame_id":0,"width":640,"height":480,"frame_rate":30,"box_type":"aabb","detections":[[100.0,100.0,200.0,300.0,0.9,0]]}' \
             > /dev/null
 
-      - name: Smoke test GPU service image
-        if: matrix.target == 'service-gpu'
-        run: |
-          nvidia-smi
-          docker run --rm --interactive --gpus all \
-            ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
-            python - <<'PY'
-          import importlib.util
-          from pathlib import Path
-
-          import torch
-
-          from boxmot.engine.service.config import ServiceSettings
-          from boxmot.reid.backends.pytorch_backend import PyTorchBackend
-          from boxmot.reid.core import ReID
-          from boxmot.trackers.registry import get_tracker_class
-
-          settings = ServiceSettings.from_env()
-          assert torch.version.cuda == "13.0", (
-              f"expected CUDA 13.0 metadata, got {torch.version.cuda!r}"
-          )
-          assert torch.cuda.is_available(), "CUDA is not exposed inside the service container"
-          assert torch.cuda.device_count() > 0, "no CUDA device is visible inside the service container"
-          probe = torch.arange(8, device="cuda", dtype=torch.float16)
-          assert probe.is_cuda and float(probe.sum().cpu()) == 28.0
-          assert importlib.util.find_spec("ultralytics") is None
-          assert importlib.util.find_spec("yolox") is None
-          assert importlib.util.find_spec("trackeval") is None
-          assert settings.profile == "gpu"
-          assert settings.tracker_type == "botsort"
-          assert settings.device == "0"
-          assert settings.half is True
-          assert settings.max_concurrent_updates == 1
-          assert Path(settings.reid_weights) == Path("/models/osnet_x0_25_msmt17.pt")
-          assert Path("/models").is_dir()
-          assert not Path(settings.reid_weights).exists(), "ReID weights must be mounted at runtime"
-          assert ReID is not None
-          assert PyTorchBackend is not None
-          for tracker_name in (
-              "strongsort",
-              "botsort",
-              "deepocsort",
-              "hybridsort",
-              "boosttrack",
-              "occluboost",
-          ):
-              assert get_tracker_class(tracker_name) is not None
-          PY
-
-          docker rm --force boxmot-service-gpu-smoke || true
-          docker volume rm boxmot-service-gpu-smoke-model || true
-          docker volume create boxmot-service-gpu-smoke-model
-          docker run --rm --interactive --user 0 --gpus all \
-            --volume boxmot-service-gpu-smoke-model:/models \
-            ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }} \
-            python - <<'PY'
-          import os
-          from pathlib import Path
-
-          import torch
-
-          from boxmot.reid.core.registry import ReIDModelRegistry
-
-          destination = Path("/models/osnet_x0_25_msmt17.pt")
-          model = ReIDModelRegistry.build_model(
-              "osnet_x0_25",
-              destination,
-              num_classes=1041,
-              pretrained=False,
-              use_gpu=False,
-          )
-          torch.save(
-              {
-                  "model_name": "osnet_x0_25",
-                  "num_classes": 1041,
-                  "state_dict": model.state_dict(),
-              },
-              destination,
-          )
-          os.chmod(destination, 0o444)
-          PY
-
-          docker run --detach \
-            --name boxmot-service-gpu-smoke \
-            --gpus all \
-            --publish 8001:8000 \
-            --volume boxmot-service-gpu-smoke-model:/models:ro \
-            ${{ matrix.repository }}:${{ env.VERSION }}${{ matrix.tag_suffix }}
-          service_ready=false
-          for attempt in {1..60}; do
-            if curl --fail --silent --show-error http://127.0.0.1:8001/healthz > /dev/null; then
-              service_ready=true
-              break
-            fi
-            sleep 1
-          done
-          if [ "$service_ready" != true ]; then
-            docker logs boxmot-service-gpu-smoke
-            exit 1
-          fi
-          curl --fail --silent --show-error http://127.0.0.1:8001/readyz \
-            > gpu-service-ready.json
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          readiness = json.loads(Path("gpu-service-ready.json").read_text())
-          assert readiness["profile"] == "gpu"
-          assert readiness["device"] == "0"
-          assert readiness["requires_image"] is True
-          PY
-          curl --fail --silent --show-error \
-            --request POST \
-            --url http://127.0.0.1:8001/v1/streams/smoke-camera/sessions/smoke-run/frames \
-            --header 'content-type: application/json' \
-            --data '{"frame_id":0,"frame_rate":30,"box_type":"aabb","detections":[[0.0,0.0,16.0,31.0,0.9,0]],"image_base64":"iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAJklEQVR4nO3NMQ0AAAwDoPo33arYsQQMkB6LQCAQCAQCgUAg+BIMi1X0pjxKe0gAAAAASUVORK5CYII="}' \
-            > gpu-service-response.json
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          response = json.loads(Path("gpu-service-response.json").read_text())
-          assert response["frame_id"] == 0
-          assert response["next_frame_id"] == 1
-          assert response["box_type"] == "aabb"
-          PY
-          service_host_pid=$(docker inspect --format '{{.State.Pid}}' boxmot-service-gpu-smoke)
-          gpu_process_pids=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)
-          if ! grep --fixed-strings --line-regexp "$service_host_pid" <<< "$gpu_process_pids"; then
-            echo "GPU service process $service_host_pid has no active CUDA context after ReID inference" >&2
-            nvidia-smi
-            docker logs boxmot-service-gpu-smoke
-            exit 1
-          fi
-
       - name: Stop CPU service smoke container
         if: always() && matrix.target == 'service-cpu'
         run: docker rm --force boxmot-service-cpu-smoke || true
-
-      - name: Stop GPU service smoke container
-        if: always() && matrix.target == 'service-gpu'
-        run: |
-          docker rm --force boxmot-service-gpu-smoke || true
-          docker volume rm boxmot-service-gpu-smoke-model || true
 
       - name: Push ${{ matrix.target }} image tags
         if: success() && (github.event_name == 'release' || inputs.push_images)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Smoke test release package and command surface
         run: |
-          python_args=(-I -)
+          python_args=(-I - --check-trackers --check-cli-help)
           case "${{ matrix.target }}" in
             # Service images deliberately run their copied source via PYTHONPATH.
             service-*) python_args=(-) ;;

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -202,7 +202,11 @@ jobs:
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
           python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py" \
-            --expected-version "$RELEASE_VERSION" --check-cli-help
+            --expected-version "$RELEASE_VERSION" --check-cli-help --check-trackers
+
+      - name: Smoke-test lazy imports and auxiliary entrypoints
+        working-directory: ${{ runner.temp }}
+        run: |
           python -I - <<'PY'
           import sys
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,18 +23,23 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /opt/boxmot
 
-# The root project owns the CPU/CUDA profiles and the single lockfile used by
-# local development, CI, and Docker. Copy metadata first for dependency-layer
-# cache reuse; package source is added only after third-party dependencies.
-COPY pyproject.toml uv.lock README.md LICENSE ./
+
+# Only this inexpensive stage reads version-bearing project metadata. Its
+# output preserves every dependency constraint, source, and locked artifact,
+# with the local project's version normalized for dependency cache reuse.
+FROM build-base AS dependency-manifests
+
+COPY docker/dependency_manifest.py /docker/dependency_manifest.py
+COPY pyproject.toml uv.lock ./
+RUN python /docker/dependency_manifest.py --output /opt/boxmot-dependencies
 
 
 FROM build-base AS cli-build-base
 
 # YOLOX compiles its fast_cocoeval extension when the yolo extra is selected.
 # The compiler remains in CLI builders and is not copied into runtime images.
-# Wheel smoke tests load the prebuilt native libraries in these builders, so
-# they need the same OpenCV runtime dependencies as the final CLI images.
+# This stage and native compilation have no project metadata ancestors, so
+# Python dependency changes and release bumps do not rebuild system packages.
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         g++ \
@@ -74,7 +79,9 @@ RUN cmake \
     && cmake --install /tmp/boxmot-native-build --strip
 
 
-FROM cli-build-base AS cli-gpu-builder
+FROM cli-build-base AS cli-gpu-dependencies
+
+COPY --from=dependency-manifests /opt/boxmot-dependencies/ ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync \
@@ -85,23 +92,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra trackeval \
         --extra cu130
 
-COPY boxmot ./boxmot
-COPY --from=native-cli-builder /opt/boxmot-native/boxmot/native/cpp/ ./boxmot/native/cpp/
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync \
-        --locked \
-        --no-dev \
-        --no-editable \
-        --reinstall-package boxmot \
-        --extra yolo \
-        --extra trackeval \
-        --extra cu130 \
-    && cd /tmp \
-    && python -I -c "import ctypes; from boxmot.native import _common; names = ('reid', 'botsort', 'bytetrack', 'occluboost', 'ocsort', 'sfsort'); paths = [_common.installed_library_candidates(name, _common.library_filename(name))[0] for name in names]; assert all(path.is_file() for path in paths), paths; [ctypes.CDLL(str(path)) for path in paths]"
+FROM cli-build-base AS cli-cpu-dependencies
 
-
-FROM cli-build-base AS cli-cpu-builder
+COPY --from=dependency-manifests /opt/boxmot-dependencies/ ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync \
@@ -112,23 +106,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra trackeval \
         --extra cpu
 
-COPY boxmot ./boxmot
-COPY --from=native-cli-builder /opt/boxmot-native/boxmot/native/cpp/ ./boxmot/native/cpp/
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync \
-        --locked \
-        --no-dev \
-        --no-editable \
-        --reinstall-package boxmot \
-        --extra yolo \
-        --extra trackeval \
-        --extra cpu \
-    && cd /tmp \
-    && python -I -c "import ctypes; from boxmot.native import _common; names = ('reid', 'botsort', 'bytetrack', 'occluboost', 'ocsort', 'sfsort'); paths = [_common.installed_library_candidates(name, _common.library_filename(name))[0] for name in names]; assert all(path.is_file() for path in paths), paths; [ctypes.CDLL(str(path)) for path in paths]"
+FROM build-base AS service-cpu-dependencies
 
-
-FROM build-base AS service-cpu-builder
+COPY --from=dependency-manifests /opt/boxmot-dependencies/ ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync \
@@ -137,10 +118,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --no-install-package boxmot \
         --only-group service-runtime
 
-COPY boxmot ./boxmot
 
+FROM build-base AS service-gpu-dependencies
 
-FROM build-base AS service-gpu-builder
+COPY --from=dependency-manifests /opt/boxmot-dependencies/ ./
 
 # The root runtime plus service extras supply HTTP/tracker/ReID dependencies;
 # cu130 activates the locked CUDA PyTorch source. BoxMOT runs from copied source.
@@ -153,7 +134,17 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra service-gpu \
         --extra cu130
 
+
+# Both CLI profiles use the same BoxMOT wheel. Build it from the actual release
+# metadata, independently of the much larger Python dependency environments.
+FROM build-base AS cli-wheel-builder
+
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY boxmot ./boxmot
+COPY --from=native-cli-builder /opt/boxmot-native/boxmot/native/cpp/ ./boxmot/native/cpp/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv build --wheel --no-sources --out-dir /wheels
 
 
 FROM python:${PYTHON_VERSION}-slim-bookworm AS cli-runtime
@@ -194,7 +185,14 @@ CMD ["bash"]
 # the PyTorch CPU wheel index selected by the `cpu` extra.
 FROM cli-runtime AS cli-cpu
 
-COPY --from=cli-cpu-builder /opt/boxmot/.venv /opt/boxmot/.venv
+# Preserve the dependency environment as its own runtime layer. Only BoxMOT's
+# wheel installation changes when application source or its version changes.
+COPY --from=cli-cpu-dependencies /opt/boxmot/.venv /opt/boxmot/.venv
+
+RUN --mount=type=bind,from=cli-wheel-builder,source=/wheels,target=/wheels \
+    uv pip install --no-cache --no-deps --python /opt/boxmot/.venv/bin/python /wheels/*.whl \
+    && cd /tmp \
+    && python -I -c "import ctypes; from boxmot.native import _common; names = ('reid', 'botsort', 'bytetrack', 'occluboost', 'ocsort', 'sfsort'); paths = [_common.installed_library_candidates(name, _common.library_filename(name))[0] for name in names]; assert all(path.is_file() for path in paths), paths; [ctypes.CDLL(str(path)) for path in paths]"
 
 
 # Shared non-root, headless service runtime. Individual CPU/GPU targets copy
@@ -239,8 +237,8 @@ FROM service-runtime AS service-cpu
 ENV BOXMOT_SERVICE_PROFILE=cpu \
     BOXMOT_SERVICE_TRACKER=bytetrack
 
-COPY --from=service-cpu-builder --chown=boxmot:boxmot /opt/boxmot/.venv /opt/boxmot/.venv
-COPY --from=service-cpu-builder --chown=boxmot:boxmot /opt/boxmot/boxmot /opt/boxmot/boxmot
+COPY --from=service-cpu-dependencies --chown=boxmot:boxmot /opt/boxmot/.venv /opt/boxmot/.venv
+COPY --chown=boxmot:boxmot boxmot /opt/boxmot/boxmot
 
 
 # CUDA ReID service. The model is not baked into the image: mount the expected
@@ -259,8 +257,8 @@ RUN apt-get update \
     && apt-get install --yes --no-install-recommends libgl1 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=service-gpu-builder --chown=boxmot:boxmot /opt/boxmot/.venv /opt/boxmot/.venv
-COPY --from=service-gpu-builder --chown=boxmot:boxmot /opt/boxmot/boxmot /opt/boxmot/boxmot
+COPY --from=service-gpu-dependencies --chown=boxmot:boxmot /opt/boxmot/.venv /opt/boxmot/.venv
+COPY --chown=boxmot:boxmot boxmot /opt/boxmot/boxmot
 
 USER boxmot
 
@@ -269,7 +267,12 @@ USER boxmot
 # their matching runtime libraries, avoiding a second CUDA stack in the base.
 FROM cli-runtime AS cli-gpu
 
-COPY --from=cli-gpu-builder /opt/boxmot/.venv /opt/boxmot/.venv
+COPY --from=cli-gpu-dependencies /opt/boxmot/.venv /opt/boxmot/.venv
+
+RUN --mount=type=bind,from=cli-wheel-builder,source=/wheels,target=/wheels \
+    uv pip install --no-cache --no-deps --python /opt/boxmot/.venv/bin/python /wheels/*.whl \
+    && cd /tmp \
+    && python -I -c "import ctypes; from boxmot.native import _common; names = ('reid', 'botsort', 'bytetrack', 'occluboost', 'ocsort', 'sfsort'); paths = [_common.installed_library_candidates(name, _common.library_filename(name))[0] for name in names]; assert all(path.is_file() for path in paths), paths; [ctypes.CDLL(str(path)) for path in paths]"
 
 
 # Preserve the familiar no-target build as an alias for the full CUDA image.

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,6 +49,33 @@ Dockerfile's bootstrap uv version aligned with it:
 uv lock
 ```
 
+## Build cache
+
+System packages, native compilation, Python dependencies, and BoxMOT installation
+have separate build layers. Changes to Python code, README, or the release
+version leave the system and native layers reusable. Native source changes
+rebuild the shared native libraries and the CLI wheel.
+
+The dependency preparation stage copies the canonical `pyproject.toml` and
+`uv.lock`, verifies their BoxMOT versions agree, and normalizes only the local
+project version in those temporary copies. CPU and CUDA dependency stages
+consume those copies with `uv sync --locked`; all dependency constraints,
+markers, sources, and artifact hashes are preserved. Version-only releases
+therefore reuse the same dependency inputs. Actual dependency changes still
+invalidate the corresponding layers.
+
+The CLI wheel is built separately from the original release metadata. Each CLI
+runtime first copies its dependency environment, then installs only that wheel
+with `--no-deps`. Updating BoxMOT changes the application layer without copying
+the complete CUDA environment again. Service images likewise copy dependencies
+and application source separately. Published package versions are unchanged by
+dependency preparation.
+
+GitHub Actions exports intermediate layers with `mode=max` and a separate cache
+scope per image target. Reuse still depends on an accessible, retained cache;
+the first build needs to populate it. The uv cache mounts speed up repeated
+commands within a builder but are not exported as download caches between jobs.
+
 ## Publish
 
 GitHub Actions builds, smoke-tests, and pushes `cli-gpu`, `cli-cpu`, and

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,14 @@
 # Docker images
 
 BoxMOT uses one shared multi-stage Dockerfile for four independently built
-images:
+images. CI publishes CPU images; build GPU images locally with the targets below:
 
 | Target | BoxMOT v24 tag | Rolling tag | Contents |
 | --- | --- | --- | --- |
-| `cli-gpu` | `boxmot/boxmot:24.0.0` | `boxmot/boxmot:latest` | Full detector, ReID, CLI, and evaluation stack with CUDA 13.0 PyTorch |
+| `cli-gpu` | Local build only | — | Full detector, ReID, CLI, and evaluation stack with CUDA 13.0 PyTorch |
 | `cli-cpu` | `boxmot/boxmot:24.0.0-cpu` | `boxmot/boxmot:latest-cpu` | The same full stack with CPU-only PyTorch |
 | `service-cpu` | `boxmot/boxmot-service:24.0.0` | `boxmot/boxmot-service:latest` | Non-root CPU geometry-only detection-to-track HTTP service |
-| `service-gpu` | `boxmot/boxmot-service:24.0.0-gpu` | `boxmot/boxmot-service:latest-gpu` | Non-root CUDA/ReID detection-to-track HTTP service |
+| `service-gpu` | Local build only | — | Non-root CUDA/ReID detection-to-track HTTP service |
 
 The CPU and CUDA selections come from mutually exclusive, lockfile-backed `cpu`
 and `cu130` extras in the root project. Docker, local development, and CI all
@@ -78,12 +78,10 @@ commands within a builder but are not exported as download caches between jobs.
 
 ## Publish
 
-GitHub Actions builds, smoke-tests, and pushes `cli-gpu`, `cli-cpu`, and
-`service-cpu` when a GitHub release is published. The `service-gpu` target is
-disabled by default. Enable it by setting the repository Actions variable
-`BOXMOT_GPU_SERVICE_CI=true` after registering a `gpu-latest` Linux NVIDIA runner
-with Docker and the NVIDIA Container Toolkit. This also enables its release
-gate and manual-workflow checks.
+GitHub Actions builds, smoke-tests, and pushes only `cli-cpu` and `service-cpu`
+when a GitHub release is published. GPU images are built by end users using
+`docker build --target cli-gpu` or `docker build --target service-gpu`; they are
+excluded from release gates, publication, and manual workflow builds.
 
 The same workflow can be dispatched manually with an
 exact commit SHA and `v<version>` release tag; manual runs validate only unless
@@ -128,7 +126,7 @@ docker run --rm --gpus all --ipc=host \
   -v "$PWD/runs/materializations:/materializations" \
   -v "$PWD/models:/opt/boxmot/models" \
   -e BOXMOT_BUILDS_DIR=/materializations \
-  boxmot/boxmot:24.0.0 \
+  boxmot/boxmot:local \
   boxmot materialize \
     --experiment mot17/ablation-yolox-lmbn.yaml \
     --device 0
@@ -145,7 +143,7 @@ docker run --rm --gpus all --ipc=host \
   -v "$PWD/runs/materializations:/materializations:ro" \
   -v "$PWD/models:/opt/boxmot/models:ro" \
   -e BOXMOT_BUILDS_DIR=/materializations \
-  boxmot/boxmot:24.0.0 \
+  boxmot/boxmot:local \
   boxmot eval \
     --experiment mot17/ablation-yolox-lmbn.yaml \
     --build "$BUILD_ID" \

--- a/docker/dependency_manifest.py
+++ b/docker/dependency_manifest.py
@@ -1,0 +1,101 @@
+"""Copy Docker dependency metadata with only BoxMOT's release version normalized.
+
+The output is for dependency-only syncs. Package builds must use the original
+metadata so the installed BoxMOT distribution retains its actual version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import tomllib
+
+CACHE_VERSION = "0.0.0"
+_TABLE_HEADER = re.compile(rb"(?m)^[ \t]*\[\[?[^\r\n]+?\]\]?[ \t]*(?:#[^\r\n]*)?\r?$")
+_VERSION_LINE = re.compile(
+    rb"(?m)^[ \t]*version[ \t]*=[ \t]*(?P<quote>[\"'])(?P<value>[^\"'\r\n]*)(?P=quote)"
+    rb"[ \t]*(?:#[^\r\n]*)?\r?$"
+)
+
+
+def _normalize_version(source: bytes, header: bytes, index: int, expected: dict) -> bytes:
+    """Replace one scalar value in a canonical TOML table without reserializing."""
+    tables = list(_TABLE_HEADER.finditer(source))
+    selected = [
+        position
+        for position, table in enumerate(tables)
+        if table.group().split(b"#", 1)[0].strip() == header
+    ]
+    if index >= len(selected):
+        raise ValueError(f"Missing canonical {header.decode()} table in dependency metadata.")
+    position = selected[index]
+    start = tables[position].end()
+    end = tables[position + 1].start() if position + 1 < len(tables) else len(source)
+    versions = list(_VERSION_LINE.finditer(source, start, end))
+    if len(versions) != 1:
+        raise ValueError(f"Expected one scalar version assignment in {header.decode()}.")
+    value = versions[0]
+    normalized = source[: value.start("value")] + CACHE_VERSION.encode() + source[value.end("value") :]
+    # TOML strings can contain text resembling headers or assignments. Fail
+    # closed if matching that text would change anything beyond the root version.
+    if tomllib.loads(normalized.decode("utf-8")) != expected:
+        raise ValueError("Normalizing dependency metadata would change fields other than the BoxMOT version.")
+    return normalized
+
+
+def normalize_dependency_manifest(pyproject: Path, lockfile: Path, output: Path) -> None:
+    """Write version-independent copies after validating the editable root pair."""
+    project_source = pyproject.read_bytes()
+    lock_source = lockfile.read_bytes()
+    project_document = tomllib.loads(project_source.decode("utf-8"))
+    lock_document = tomllib.loads(lock_source.decode("utf-8"))
+    project = project_document.get("project")
+    if not isinstance(project, dict) or project.get("name") != "boxmot":
+        raise ValueError("pyproject.toml must declare the boxmot project.")
+    version = project.get("version")
+    dynamic = project.get("dynamic", [])
+    if not isinstance(dynamic, list):
+        raise ValueError("pyproject.toml dynamic metadata must be a list of field names.")
+    if not isinstance(version, str) or not version or "version" in dynamic:
+        raise ValueError("pyproject.toml must declare a nonempty static project version.")
+    packages = lock_document.get("package")
+    if not isinstance(packages, list) or not all(isinstance(package, dict) for package in packages):
+        raise ValueError("uv.lock must declare package records.")
+    roots = [index for index, package in enumerate(packages) if package.get("name") == "boxmot"]
+    editable_roots = [index for index, package in enumerate(packages) if package.get("source") == {"editable": "."}]
+    if len(roots) != 1 or editable_roots != roots:
+        raise ValueError("uv.lock must contain exactly one local editable boxmot root package.")
+    root = packages[roots[0]]
+    if root.get("version") != version:
+        raise ValueError("The project and local editable boxmot lock versions must match.")
+
+    project["version"] = root["version"] = CACHE_VERSION
+    normalized_project = _normalize_version(project_source, b"[project]", 0, project_document)
+    normalized_lock = _normalize_version(lock_source, b"[[package]]", roots[0], lock_document)
+    targets = (output / "pyproject.toml", output / "uv.lock")
+    for target in targets:
+        for original in (pyproject, lockfile):
+            if target.resolve() == original.resolve() or (target.exists() and target.samefile(original)):
+                raise ValueError("Dependency metadata output must not overwrite either original input.")
+    output.mkdir(parents=True, exist_ok=True)
+    for target, content in zip(targets, (normalized_project, normalized_lock), strict=True):
+        target.write_bytes(content)
+
+
+def main() -> None:
+    """Prepare dependency-only metadata from the current checkout or explicit paths."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
+    parser.add_argument("--lockfile", type=Path, default=Path("uv.lock"))
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        normalize_dependency_manifest(args.pyproject, args.lockfile, args.output)
+    except (OSError, UnicodeError, ValueError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -114,6 +114,17 @@ imports on Python 3.10 through 3.13. Docker validates `cli-cpu`, `cli-gpu`, and
 requested release version with the candidate and installed artifacts; they do
 not pin a particular version.
 
+The installed-wheel smoke resolves every public tracker class and creates each
+tracker through `create_tracker(TrackerSpec(...))` using its packaged defaults.
+It runs a short CPU sequence in AABB and OBB modes, including an initial empty
+batch, and checks output layouts, detection associations, class IDs, and stable
+track IDs. Synthetic embeddings and masks satisfy tracker requirements without
+model downloads. A direct ByteTrack call also checks the packed NumPy API.
+Every public CLI command runs through the installed `boxmot <command> --help`
+entrypoint. These checks run outside the source checkout with isolated Python
+imports, and also run in the full CLI Docker images. Service images retain
+their HTTP request checks with the smaller service dependency set.
+
 After these gates pass, the workflow publishes the checksummed wheel and source
 distribution. Successful **PyPI** publication is followed by an atomic push of
 the tested version commit and its `v<version>` tag, then a GitHub release at that

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -125,6 +125,14 @@ entrypoint. These checks run outside the source checkout with isolated Python
 imports, and also run in the full CLI Docker images. Service images retain
 their HTTP request checks with the smaller service dependency set.
 
+Docker builds cache system packages and native compilation independently of
+project metadata. Dependency stages use temporary copies of the canonical
+project and lock files with only BoxMOT's own version normalized, so a
+version-only bump does not reinstall third-party packages. CLI images copy
+the dependency environment before installing the separately built BoxMOT wheel;
+the wheel always retains the actual release version. See the repository's
+`docker/README.md` for the cache layout and invalidation rules.
+
 After these gates pass, the workflow publishes the checksummed wheel and source
 distribution. Successful **PyPI** publication is followed by an atomic push of
 the tested version commit and its `v<version>` tag, then a GitHub release at that

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -109,8 +109,8 @@ in the `release-source` bundle artifact without pushing the branch or a tag.
 
 Every release gate restores that exact candidate. The reusable wheel workflow
 runs the full tests, strict documentation build, native checks, and clean-wheel
-imports on Python 3.10 through 3.13. Docker validates `cli-cpu`, `cli-gpu`, and
-`service-cpu` by default, without pushing them. Package checks compare the
+imports on Python 3.10 through 3.13. Docker validates `cli-cpu` and
+`service-cpu`, without pushing them. Package checks compare the
 requested release version with the candidate and installed artifacts; they do
 not pin a particular version.
 
@@ -149,13 +149,8 @@ recover the tested candidate from the bundle artifact instead of rebuilding or
 force-pushing another commit. PyPI publication requires `RELEASE_PAT` with
 permission to push the version commit and tag and create the release.
 
-The `service-gpu` target is disabled by default so releases can run without a
-GPU runner. To enable its build, smoke test, and image publication, set the
-repository Actions variable `BOXMOT_GPU_SERVICE_CI` to `true` after registering
-a `gpu-latest` Linux NVIDIA runner with Docker and the NVIDIA Container Toolkit.
-This setting applies to release gates, published releases, and manual Docker runs.
-The enabled smoke exposes the GPU to the container, performs CUDA-backed ReID
-enrichment through the HTTP service, and verifies that the service owns an
-active CUDA context. The CPU
-service smoke uses the CPU-only Torch image and exercises the same `/v1`
-request boundary without CUDA.
+CI builds, validates, and publishes only CPU images. GPU images are built by
+end users with the `cli-gpu` or `service-gpu` Dockerfile target; release gates,
+published releases, and manual workflow runs never schedule GPU image builds.
+The CPU service smoke uses CPU-only Torch and exercises the `/v1` request
+boundary without CUDA.

--- a/tests/ci/python_api_smoke.py
+++ b/tests/ci/python_api_smoke.py
@@ -2,35 +2,21 @@
 
 from __future__ import annotations
 
-import numpy as np
 import torch
 from click.testing import CliRunner
 
-from boxmot import ByteTrack, create_tracker
 from boxmot.engine.cli import boxmot as boxmot_cli
-from boxmot.trackers import TrackerSpec
-from tests.ci.release_contract import EXPECTED_CLI_COMMANDS, check_release_contract
+from tests.ci.release_contract import EXPECTED_CLI_COMMANDS, check_release_contract, check_tracker_api
 
 
 def test_python_api_smoke() -> None:
-    """Exercise direct NumPy tracking through the public API on CPU."""
+    """Exercise all public tracker imports and synthetic tracking on CPU."""
 
     assert torch.version.cuda is None, f"Expected CPU-only PyTorch, got torch {torch.__version__}"
     assert not torch.cuda.is_available()
     # Compare runtime to installed metadata; refresh editable installs after a bump.
     check_release_contract()
-
-    tracker = create_tracker(TrackerSpec("bytetrack"))
-    assert isinstance(tracker, ByteTrack)
-
-    dets = np.array([[100, 200, 300, 400, 0.9, 0]], dtype=np.float32)
-    tracks = tracker.update(dets)
-    next_tracks = tracker.update(dets)
-    assert type(tracks) is np.ndarray
-    assert type(next_tracks) is np.ndarray
-    assert tracks.shape == (1, 8)
-    assert next_tracks.shape == (1, 8)
-    assert next_tracks[:, 4].tolist() == tracks[:, 4].tolist()
+    check_tracker_api()
 
 
 def test_cli_command_surface_smoke() -> None:

--- a/tests/ci/release_contract.py
+++ b/tests/ci/release_contract.py
@@ -7,20 +7,19 @@ import importlib.metadata
 import importlib.util
 import subprocess
 
-EXPECTED_PUBLIC_API = (
-    "__version__",
-    "create_tracker",
-    "BoostTrack",
-    "BotSort",
-    "ByteTrack",
-    "DeepOcSort",
-    "HybridSort",
-    "OccluBoost",
-    "OcSort",
-    "Sam2Mot",
-    "SFSORT",
-    "StrongSort",
+EXPECTED_TRACKERS = (
+    ("boosttrack", "BoostTrack"),
+    ("botsort", "BotSort"),
+    ("bytetrack", "ByteTrack"),
+    ("deepocsort", "DeepOcSort"),
+    ("hybridsort", "HybridSort"),
+    ("occluboost", "OccluBoost"),
+    ("ocsort", "OcSort"),
+    ("sam2mot", "Sam2Mot"),
+    ("sfsort", "SFSORT"),
+    ("strongsort", "StrongSort"),
 )
+EXPECTED_PUBLIC_API = ("__version__", "create_tracker", *(public_name for _, public_name in EXPECTED_TRACKERS))
 EXPECTED_CLI_COMMANDS = (
     "track",
     "materialize",
@@ -78,6 +77,114 @@ def check_cli_help() -> None:
         assert result.returncode == 0, f"boxmot {command} --help failed:\n{result.stdout}\n{result.stderr}"
 
 
+def check_tracker_imports() -> dict[str, type]:
+    """Resolve every public lazy export, so missing implementation files fail."""
+    import boxmot
+
+    classes = {}
+    for name, public_name in EXPECTED_TRACKERS:
+        tracker_class = getattr(boxmot, public_name)
+        assert isinstance(tracker_class, type), f"boxmot.{public_name} is not a tracker class"
+        assert tracker_class.__name__ == public_name, f"boxmot.{public_name} resolves to {tracker_class!r}"
+        assert callable(getattr(tracker_class, "update", None)), f"boxmot.{public_name} has no update method"
+        classes[name] = tracker_class
+    return classes
+
+
+def check_tracker_tracking(name: str, tracker_class: type, geometry: str) -> None:
+    """Exercise installed defaults, empty input, and two identities on CPU."""
+    import numpy as np
+    import torch
+
+    from boxmot import create_tracker
+    from boxmot.structures import Boxes, Detections, Frame, MaskBatch, OrientedBoxes, Tracks
+    from boxmot.trackers import TrackerSpec
+
+    tracker = create_tracker(TrackerSpec(name, geometry=geometry))
+    label = f"{name}/{geometry}"
+    assert type(tracker) is tracker_class, f"{label}: factory returned {type(tracker)!r}"
+    is_obb = geometry == "obb"
+    geometry_type = OrientedBoxes if is_obb else Boxes
+    values = torch.tensor(
+        [[27, 35, 26, 27, 0.2], [75, 47, 26, 39, -0.3]]
+        if is_obb else [[14, 21, 40, 48], [62, 28, 88, 67]],
+        dtype=torch.float32,
+    )
+    height, width = 240, 320
+    image = torch.from_numpy(np.random.default_rng(0).integers(0, 256, (3, height, width), dtype=np.uint8))
+    masks = torch.zeros((2, height, width), dtype=torch.bool)
+    masks[0, 21:48, 14:40] = True
+    masks[1, 28:67, 62:88] = True
+    embeddings = torch.eye(2, 4, dtype=torch.float32)
+    class_ids = torch.tensor([0, 65], dtype=torch.int64)
+
+    def update(frame_index: int, count: int) -> Tracks:
+        """Supply required enrichments explicitly and verify canonical output."""
+        sample_id = f"release-smoke/{frame_index}"
+        detections = Detections(
+            geometry=geometry_type(values[:count].clone()),
+            scores=torch.full((count,), 0.99, dtype=torch.float32),
+            class_ids=class_ids[:count].clone(),
+            sample_id=sample_id,
+            embeddings=embeddings[:count].clone() if tracker.requirements.embeddings else None,
+            masks=MaskBatch(masks[:count].clone()) if tracker.requirements.masks else None,
+        )
+        frame = (
+            Frame(image=image.clone(), sample_id=sample_id, sequence_id="release-smoke", frame_index=frame_index)
+            if tracker.requirements.frame else None
+        )
+        output = tracker.update(detections, frame)
+        assert isinstance(output, Tracks), f"{label}: canonical input did not return Tracks"
+        assert isinstance(output.geometry, geometry_type), f"{label}: incorrect output geometry"
+        assert output.sample_id == sample_id, f"{label}: output belongs to a different frame"
+        rows = output.to_obb_rows() if is_obb else output.to_aabb_rows()
+        assert rows.shape == (len(output), 9 if is_obb else 8), f"{label}: incorrect output layout"
+        assert torch.isfinite(rows).all(), f"{label}: non-finite tracking output"
+        if tracker.requirements.masks:
+            assert output.masks is not None, f"{label}: missing output masks"
+            assert output.masks.values.shape == (len(output), height, width), f"{label}: incorrect mask layout"
+        return output
+
+    assert len(update(0, 0)) == 0, f"{label}: empty initial input produced tracks"
+    previous_ids = None
+    for frame_index in range(1, 7):
+        output = update(frame_index, 2)
+        # Allow the default confirmation period before checking both identities.
+        if frame_index >= 5:
+            assert len(output) == 2, f"{label}: expected two confirmed tracks, got {len(output)}"
+            indices = output.detection_indices
+            assert sorted(indices.tolist()) == [0, 1], f"{label}: incorrect detection associations"
+            assert torch.equal(output.class_ids, class_ids[indices]), f"{label}: class IDs changed"
+            identities = dict(zip(indices.tolist(), output.track_ids.tolist()))
+            assert len(set(identities.values())) == 2, f"{label}: duplicate track IDs"
+            if previous_ids is not None:
+                assert identities == previous_ids, f"{label}: track IDs changed between matching frames"
+            previous_ids = identities
+    print(f"Tracker smoke passed: {label}", flush=True)
+
+
+def check_tracker_api() -> None:
+    """Import and run all shipped Python trackers without fetching any models."""
+    import numpy as np
+
+    from boxmot import ByteTrack
+
+    for name, tracker_class in check_tracker_imports().items():
+        for geometry in ("aabb", "obb"):
+            check_tracker_tracking(name, tracker_class, geometry)
+
+    # Also exercise the direct class constructor and common packed NumPy API.
+    tracker = ByteTrack()
+    detections = np.array([[14, 21, 40, 48, 0.99, 0]], dtype=np.float32)
+    first = tracker.update(detections)
+    second = tracker.update(detections)
+    for output in (first, second):
+        assert isinstance(output, np.ndarray) and output.shape == (1, 8), "ByteTrack: invalid NumPy output"
+        assert output.dtype == np.float64 and output.flags.c_contiguous, "ByteTrack: invalid packed layout"
+        assert np.isfinite(output).all(), "ByteTrack: non-finite NumPy output"
+    np.testing.assert_array_equal(first[:, 4], second[:, 4])
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -85,8 +192,13 @@ if __name__ == "__main__":
         help="Expected runtime version; defaults to the installed BoxMOT distribution version.",
     )
     parser.add_argument("--check-cli-help", action="store_true", help="Also exercise every installed command's help.")
+    parser.add_argument(
+        "--check-trackers", action="store_true", help="Import every public tracker and exercise CPU tracking."
+    )
     args = parser.parse_args()
     check_release_contract(expected_version=args.expected_version)
     if args.check_cli_help:
         check_cli_help()
-    print("Release public API, CLI, and packaged configuration checks passed.")
+    if args.check_trackers:
+        check_tracker_api()
+    print("Requested release contract checks passed.")

--- a/tests/unit/test_docker_cache_layers.py
+++ b/tests/unit/test_docker_cache_layers.py
@@ -1,0 +1,139 @@
+"""Protect the Docker boundaries between system, dependency, and application layers."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Iterator
+
+import pytest
+
+from tests.unit.test_docker_native_runtime import _stages
+
+Stages = dict[str, tuple[str, list[str]]]
+PROFILES = {
+    "cli-cpu": ({"cpu", "yolo", "trackeval"}, set()),
+    "cli-gpu": ({"cu130", "yolo", "trackeval"}, set()),
+    "service-cpu": (set(), {"service-runtime"}),
+    "service-gpu": ({"cu130", "service", "service-gpu"}, set()),
+}
+
+
+def _lineage(stages: Stages, name: str) -> Iterator[str]:
+    """Follow FROM ancestry; copying files does not inherit a stage's layers."""
+    while name in stages:
+        yield name
+        name = stages[name][0]
+
+
+def _instructions(stages: Stages, name: str) -> list[str]:
+    """Return inherited instructions in build order."""
+    return [instruction for stage in reversed(list(_lineage(stages, name))) for instruction in stages[stage][1]]
+
+
+def _copies(instructions: list[str]) -> Iterator[tuple[str | None, tuple[str, ...], str]]:
+    """Read each COPY's origin, source paths, and destination, ignoring other flags."""
+    for instruction in instructions:
+        if not instruction.startswith("COPY "):
+            continue
+        words = shlex.split(instruction)[1:]
+        origin = next((word.removeprefix("--from=") for word in words if word.startswith("--from=")), None)
+        paths = [word for word in words if not word.startswith("--")]
+        yield origin, tuple(paths[:-1]), paths[-1]
+
+
+def _command(instructions: list[str], *command: str) -> tuple[int, list[str]]:
+    """Locate a unique shell command without mistaking comments for instructions."""
+    matches = []
+    for index, instruction in enumerate(instructions):
+        if not instruction.startswith("RUN "):
+            continue
+        words = shlex.split(instruction)
+        if any(words[offset : offset + len(command)] == list(command) for offset in range(len(words))):
+            matches.append((index, words))
+    assert len(matches) == 1, f"Expected one {' '.join(command)} command, found {len(matches)}"
+    return matches[0]
+
+
+def _values(words: list[str], option: str) -> set[str]:
+    """Collect values for a repeated CLI option."""
+    return {words[index + 1] for index, word in enumerate(words[:-1]) if word == option}
+
+
+def test_system_package_layers_do_not_depend_on_project_files() -> None:
+    """No metadata or application copy may precede apt, including in parent stages."""
+    stages = _stages()
+    checked = []
+    for name, (parent, instructions) in stages.items():
+        for index, instruction in enumerate(instructions):
+            if instruction.startswith("RUN ") and "apt-get install" in instruction:
+                copies = list(_copies(_instructions(stages, parent) + instructions[:index]))
+                assert all(origin == "uv" for origin, _, _ in copies), (name, copies)
+                checked.append(name)
+    assert checked
+
+
+def test_native_compilation_depends_only_on_native_source() -> None:
+    """Release metadata and Python dependencies cannot invalidate native compilation."""
+    copies = list(_copies(_instructions(_stages(), "native-cli-builder")))
+    assert {source for origin, sources, _ in copies if origin is None for source in sources} == {"boxmot/native/cpp"}
+    assert {origin for origin, _, _ in copies if origin is not None} == {"uv"}
+
+
+@pytest.mark.parametrize("target", PROFILES)
+def test_dependency_stages_consume_only_normalized_metadata(target: str) -> None:
+    """Only normalized files cross into dependency builders; no raw metadata layers do."""
+    stages = _stages()
+    name = f"{target}-dependencies"
+    assert "dependency-manifests" not in _lineage(stages, name)
+    instructions = _instructions(stages, name)
+    copies = [copy for copy in _copies(instructions) if copy[0] != "uv"]
+    assert copies == [("dependency-manifests", ("/opt/boxmot-dependencies/",), "./")]
+    _, words = _command(instructions, "uv", "sync")
+    assert {"--locked", "--no-dev"} <= set(words)
+    assert _values(words, "--no-install-package") == {"boxmot"}
+    extras, groups = PROFILES[target]
+    assert _values(words, "--extra") == extras
+    assert _values(words, "--only-group") == groups
+
+
+@pytest.mark.parametrize("target", PROFILES)
+def test_runtime_dependency_copy_precedes_application_layer(target: str) -> None:
+    """Runtime images retain the dependency-only venv as a separate reusable layer."""
+    instructions = _instructions(_stages(), target)
+    copies = list(_copies(instructions))
+    venv = [copy for copy in copies if copy[2] == "/opt/boxmot/.venv"]
+    assert venv == [(f"{target}-dependencies", ("/opt/boxmot/.venv",), "/opt/boxmot/.venv")]
+    dependency_index = next(index for index, row in enumerate(instructions) if f"--from={target}-dependencies " in row)
+    if target.startswith("cli-"):
+        application_index, words = _command(instructions, "uv", "pip", "install")
+        assert {"--no-deps", "--no-cache", "/wheels/*.whl"} <= set(words)
+        assert _values(words, "--python") == {"/opt/boxmot/.venv/bin/python"}
+        mounts = [
+            dict(item.split("=", 1) for item in word.removeprefix("--mount=").split(","))
+            for word in words
+            if word.startswith("--mount=")
+        ]
+        assert {"type": "bind", "from": "cli-wheel-builder", "source": "/wheels", "target": "/wheels"} in mounts
+        assert not any(origin is None for origin, _, _ in copies)
+        assert not any("UV_COMPILE_BYTECODE=1" in row or "--compile-bytecode" in row for row in instructions)
+    else:
+        assert [copy for copy in copies if copy[0] is None] == [(None, ("boxmot",), "/opt/boxmot/boxmot")]
+        application_index = next(
+            index
+            for index, row in enumerate(instructions)
+            if row.startswith("COPY ") and " boxmot /opt/boxmot/boxmot" in row
+        )
+    assert dependency_index < application_index
+    assert not any(row.startswith("RUN ") and "uv sync" in row for row in instructions)
+
+
+def test_shared_wheel_builder_uses_real_metadata_without_dependency_environments() -> None:
+    """The application wheel retains the release version and combines native artifacts once."""
+    instructions = _instructions(_stages(), "cli-wheel-builder")
+    copies = list(_copies(instructions))
+    context_sources = {source for origin, sources, _ in copies if origin is None for source in sources}
+    assert {"pyproject.toml", "README.md", "LICENSE", "boxmot"} <= context_sources
+    assert {origin for origin, _, _ in copies if origin is not None} == {"uv", "native-cli-builder"}
+    assert not any(".venv" in source for _, sources, _ in copies for source in sources)
+    _, words = _command(instructions, "uv", "build")
+    assert {"--wheel", "--no-sources"} <= set(words)

--- a/tests/unit/test_docker_dependency_manifest.py
+++ b/tests/unit/test_docker_dependency_manifest.py
@@ -1,0 +1,281 @@
+"""Validate release-stable dependency metadata without weakening uv's lock checks."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+tomllib = pytest.importorskip("tomllib", reason="Docker metadata preparation uses Python 3.11 or newer.")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "docker" / "dependency_manifest.py"
+SPEC = importlib.util.spec_from_file_location("dependency_manifest", SCRIPT)
+dependency_manifest = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(dependency_manifest)
+
+
+@pytest.fixture
+def metadata(tmp_path: Path) -> tuple[Path, Path]:
+    """Include same-version third parties, nested metadata, comments, and CRLFs."""
+    pyproject = tmp_path / "pyproject.toml"
+    lockfile = tmp_path / "uv.lock"
+    pyproject.write_bytes(
+        b'# Keep metadata formatting.\r\n[project]\r\nname = "boxmot"\r\n'
+        b"version \t = '24.0.0'  # Actual release\r\n"
+        b'dependencies = ["example==24.0.0"]\r\n'
+        b'[tool.example]\r\nversion = "24.0.0"\r\n'
+    )
+    lockfile.write_bytes(
+        b'version = 1\nrevision = 3\nrequires-python = ">=3.11"\n'
+        b'[[package]]\nname = "example"\nversion = "24.0.0"\n'
+        b'source = { registry = "https://pypi.org/simple" }\n'
+        b'sdist = { url = "https://example.invalid/example.tar.gz", hash = "sha256:abc123" }\n'
+        b'[[package]]\nname = "boxmot"\nversion = "24.0.0" # Root only\n'
+        b'source = { editable = "." }\n'
+        b'dependencies = [{ name = "example", marker = "sys_platform == \'linux\'" }]\n'
+        b'[package.metadata]\nrequires-dist = [{ name = "example", specifier = "==24.0.0" }]\n'
+    )
+    return pyproject, lockfile
+
+
+def _normalize(metadata: tuple[Path, Path], output: Path) -> tuple[bytes, bytes]:
+    """Return exactly the files consumed by Docker's dependency stages."""
+    dependency_manifest.normalize_dependency_manifest(*metadata, output)
+    return (output / "pyproject.toml").read_bytes(), (output / "uv.lock").read_bytes()
+
+
+def test_only_the_two_root_versions_change(metadata: tuple[Path, Path], tmp_path: Path) -> None:
+    before = tuple(path.read_bytes() for path in metadata)
+
+    result = _normalize(metadata, tmp_path / "dependencies")
+
+    assert result == (
+        before[0].replace(b"version \t = '24.0.0'", b"version \t = '0.0.0'", 1),
+        before[1].replace(b'version = "24.0.0" # Root only', b'version = "0.0.0" # Root only', 1),
+    )
+    assert tuple(path.read_bytes() for path in metadata) == before
+
+
+@pytest.mark.parametrize("release", ("24.0.1", "24.1.0", "25.0.0"))
+def test_release_only_bumps_have_identical_outputs(
+    metadata: tuple[Path, Path], tmp_path: Path, release: str
+) -> None:
+    baseline = _normalize(metadata, tmp_path / "before")
+    pyproject, lockfile = metadata
+    pyproject.write_bytes(
+        pyproject.read_bytes().replace(b"version \t = '24.0.0'", f"version \t = '{release}'".encode(), 1)
+    )
+    lockfile.write_bytes(
+        lockfile.read_bytes().replace(
+            b'version = "24.0.0" # Root only', f'version = "{release}" # Root only'.encode(), 1
+        )
+    )
+
+    assert _normalize(metadata, tmp_path / "after") == baseline
+
+
+@pytest.mark.parametrize(
+    "index,old,new",
+    (
+        (0, b"example==24.0.0", b"example>=24.0.0"),
+        (0, b"[tool.example]", b"[tool.another]"),
+        (1, b'name = "example"\nversion = "24.0.0"', b'name = "example"\nversion = "24.0.1"'),
+        (1, b"https://pypi.org/simple", b"https://registry.example.invalid/simple"),
+        (1, b"sha256:abc123", b"sha256:def456"),
+        (1, b"sys_platform == 'linux'", b"sys_platform == 'darwin'"),
+        (1, b'specifier = "==24.0.0"', b'specifier = ">=24.0.0"'),
+    ),
+)
+def test_dependency_metadata_changes_invalidate_outputs(
+    metadata: tuple[Path, Path], tmp_path: Path, index: int, old: bytes, new: bytes
+) -> None:
+    baseline = _normalize(metadata, tmp_path / "before")
+    original = metadata[index].read_bytes()
+    assert old in original
+    metadata[index].write_bytes(original.replace(old, new, 1))
+
+    assert _normalize(metadata, tmp_path / "after") != baseline
+
+
+@pytest.mark.parametrize(
+    "index,old,new,error",
+    (
+        (0, b'name = "boxmot"', b'name = "other"', "boxmot project"),
+        (0, b"version \t = '24.0.0'", b"version \t = 24", "static project version"),
+        (0, b"version \t = '24.0.0'", b"version \t = ''", "static project version"),
+        (0, b"[tool.example]", b'dynamic = ["version"]\r\n[tool.example]', "static project version"),
+        (1, b'name = "boxmot"', b'name = "other"', "exactly one local editable boxmot"),
+        (1, b'editable = "."', b'editable = "../boxmot"', "exactly one local editable boxmot"),
+        (1, b'editable = "."', b'virtual = "."', "exactly one local editable boxmot"),
+        (1, b'version = "24.0.0" # Root only', b'version = "24.0.1" # Root only', "versions must match"),
+        (1, b"[[package]]", b"[package]", "Cannot overwrite a value"),
+    ),
+)
+def test_invalid_inputs_fail_before_writing(
+    metadata: tuple[Path, Path], tmp_path: Path, index: int, old: bytes, new: bytes, error: str
+) -> None:
+    metadata[index].write_bytes(metadata[index].read_bytes().replace(old, new, 1))
+    before = tuple(path.read_bytes() for path in metadata)
+    output = tmp_path / "dependencies"
+
+    with pytest.raises(ValueError, match=error):
+        _normalize(metadata, output)
+
+    assert not output.exists()
+    assert tuple(path.read_bytes() for path in metadata) == before
+
+
+@pytest.mark.parametrize("name", ("boxmot", "other"))
+def test_duplicate_root_records_are_rejected(metadata: tuple[Path, Path], tmp_path: Path, name: str) -> None:
+    lockfile = metadata[1]
+    lockfile.write_bytes(
+        lockfile.read_bytes()
+        + f'\n[[package]]\nname = "{name}"\nversion = "24.0.0"\nsource = {{ editable = "." }}\n'.encode()
+    )
+
+    with pytest.raises(ValueError, match="exactly one local editable boxmot"):
+        _normalize(metadata, tmp_path / "dependencies")
+
+
+@pytest.mark.parametrize("alias", ("same-directory", "symlink", "hardlink"))
+def test_outputs_cannot_overwrite_inputs(metadata: tuple[Path, Path], tmp_path: Path, alias: str) -> None:
+    before = tuple(path.read_bytes() for path in metadata)
+    output = tmp_path if alias == "same-directory" else tmp_path / "dependencies"
+    if alias != "same-directory":
+        output.mkdir()
+        target = output / "pyproject.toml"
+        if alias == "symlink":
+            target.symlink_to(metadata[0])
+        else:
+            target.hardlink_to(metadata[0])
+
+    with pytest.raises(ValueError, match="must not overwrite"):
+        _normalize(metadata, output)
+
+    assert tuple(path.read_bytes() for path in metadata) == before
+
+
+def test_header_text_in_multiline_strings_cannot_change_unrelated_fields(
+    metadata: tuple[Path, Path], tmp_path: Path
+) -> None:
+    pyproject = metadata[0]
+    pyproject.write_bytes(b'example = """\n[project]\nversion = \'24.0.0\'\n"""\n' + pyproject.read_bytes())
+
+    with pytest.raises(ValueError, match="fields other than the BoxMOT version"):
+        _normalize(metadata, tmp_path / "dependencies")
+
+
+def test_cli_accepts_metadata_from_its_working_directory(metadata: tuple[Path, Path], tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--output", str(tmp_path / "cli-output")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "cli-output" / "pyproject.toml").read_bytes() == _normalize(metadata, tmp_path / "direct")[0]
+
+
+@pytest.mark.parametrize(
+    "profile",
+    (
+        ("--extra", "cpu", "--extra", "yolo", "--extra", "trackeval"),
+        ("--extra", "cu130", "--extra", "yolo", "--extra", "trackeval"),
+        ("--only-group", "service-runtime"),
+        ("--extra", "cu130", "--extra", "service", "--extra", "service-gpu"),
+    ),
+)
+def test_repository_dependency_exports_are_unchanged_offline(tmp_path: Path, profile: tuple[str, ...]) -> None:
+    """Compare full locked dependency graphs, including hashes, for every image."""
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("Docker lock validation requires the repository's pinned uv executable.")
+    output = tmp_path / "dependencies"
+    _normalize((REPO_ROOT / "pyproject.toml", REPO_ROOT / "uv.lock"), output)
+    original = tmp_path / "original"
+    original.mkdir()
+    for name in ("pyproject.toml", "uv.lock"):
+        (original / name).write_bytes((REPO_ROOT / name).read_bytes())
+    environment = {
+        **os.environ,
+        "UV_OFFLINE": "1",
+        "UV_PYTHON": sys.executable,
+        "UV_PYTHON_DOWNLOADS": "never",
+        "UV_CACHE_DIR": str(tmp_path / "uv-cache"),
+        "UV_PROJECT_ENVIRONMENT": str(tmp_path / "unused-venv"),
+    }
+    exports = []
+    for directory in (original, output):
+        before = tuple((directory / name).read_bytes() for name in ("pyproject.toml", "uv.lock"))
+        result = subprocess.run(
+            [uv, "export", "--frozen", "--no-dev", "--no-emit-project", "--no-header", *profile],
+            cwd=directory,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert tuple((directory / name).read_bytes() for name in ("pyproject.toml", "uv.lock")) == before
+        exports.append(result.stdout)
+
+    assert exports[0] == exports[1]
+    assert "--hash=sha256:" in exports[0]
+    assert not (tmp_path / "unused-venv").exists()
+    assert not (output / ".venv").exists()
+
+
+def test_normalized_manifest_passes_uv_locked_sync_offline(tmp_path: Path) -> None:
+    """Check freshness with a real third-party dependency and no registry cache."""
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("Docker lock validation requires the repository's pinned uv executable.")
+    original = tmp_path / "original"
+    original.mkdir()
+    example = tmp_path / "example"
+    example.mkdir()
+    (example / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "24.0.0"\nrequires-python = ">=3.11"\n'
+        '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n',
+        encoding="utf-8",
+    )
+    (original / "pyproject.toml").write_text(
+        '[project]\nname = "boxmot"\nversion = "24.0.0"\nrequires-python = ">=3.11"\n'
+        'dependencies = ["example==24.0.0"]\n'
+        '[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+        '[tool.uv]\npreview = true\nrequired-version = "==0.12.4"\n'
+        '[tool.uv.sources]\nexample = { path = "../example" }\n',
+        encoding="utf-8",
+    )
+    environment = {
+        **os.environ,
+        "UV_OFFLINE": "1",
+        "UV_PYTHON": sys.executable,
+        "UV_PYTHON_DOWNLOADS": "never",
+        "UV_CACHE_DIR": str(tmp_path / "uv-cache"),
+        "UV_PROJECT_ENVIRONMENT": str(tmp_path / "unused-venv"),
+    }
+    subprocess.run([uv, "lock"], cwd=original, env=environment, capture_output=True, text=True, check=True)
+    output = tmp_path / "dependencies"
+    normalized = _normalize((original / "pyproject.toml", original / "uv.lock"), output)
+    result = subprocess.run(
+        [uv, "sync", "--locked", "--dry-run", "--no-dev", "--no-install-package", "boxmot"],
+        cwd=output,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert tuple((output / name).read_bytes() for name in ("pyproject.toml", "uv.lock")) == normalized
+    assert not (tmp_path / "unused-venv").exists()
+    assert not (output / ".venv").exists()

--- a/tests/unit/test_docker_native_runtime.py
+++ b/tests/unit/test_docker_native_runtime.py
@@ -51,7 +51,7 @@ def _packages_at_end(stages: dict[str, tuple[str, list[str]]], name: str) -> set
 
 
 def test_native_library_smokes_have_opencv_before_loading() -> None:
-    """A later runtime stage cannot satisfy a builder's earlier ctypes smoke."""
+    """Both final CLI environments load native libraries after their apt install."""
     stages = _stages()
     checked = []
     for name, (parent, instructions) in stages.items():
@@ -63,7 +63,7 @@ def test_native_library_smokes_have_opencv_before_loading() -> None:
                 missing = OPENCV_RUNTIME_PACKAGES - packages
                 assert not missing, f"{name} loads native libraries without runtime packages: {sorted(missing)}"
                 checked.append(name)
-    assert checked, "Retain native-library load validation in CLI wheel builders."
+    assert set(checked) == {"cli-cpu", "cli-gpu"}, "Validate native libraries in both final CLI environments."
 
 
 @pytest.mark.parametrize("target", ("cli-cpu", "cli-gpu", "default"))

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
@@ -33,55 +32,26 @@ def _docker_stage(name: str) -> str:
     return dockerfile.split(marker, 1)[1].split("\nFROM ", 1)[0]
 
 
-def _selected_images(tmp_path: Path, enabled: str | None) -> list[dict]:
-    """Execute the workflow's matrix selection without scheduling any runners."""
-    workflow = yaml.safe_load(DOCKER_WORKFLOW.read_text(encoding="utf-8"))
-    selection = workflow["jobs"]["prepare-matrix"]
-    step = next(step for step in selection["steps"] if step.get("id") == "images")
-    assert selection["runs-on"] == "ubuntu-latest"
-    assert step["env"]["ENABLE_GPU_SERVICE"] == "${{ vars.BOXMOT_GPU_SERVICE_CI }}"
-    env = {key: value for key, value in os.environ.items() if key != "ENABLE_GPU_SERVICE"}
-    if enabled is not None:
-        env["ENABLE_GPU_SERVICE"] = enabled
-    output = tmp_path / "matrix-output"
-    env["GITHUB_OUTPUT"] = str(output)
-    result = subprocess.run(
-        ["bash", "-e", "-o", "pipefail", "-c", step["run"]],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr
-    name, _, value = output.read_text(encoding="utf-8").strip().partition("=")
-    assert name == "matrix"
-    return json.loads(value)["include"]
-
-
-@pytest.mark.parametrize("enabled", (None, "", "false"))
-def test_docker_defaults_schedule_only_available_hosted_runners(tmp_path: Path, enabled: str | None) -> None:
-    matrix = _selected_images(tmp_path, enabled)
-    assert {entry["target"] for entry in matrix} == {"cli-gpu", "cli-cpu", "service-cpu"}
-    assert {entry["runner"] for entry in matrix} == {"ubuntu-latest"}
-
-
-def test_enabled_gpu_matrix_covers_every_image_with_bounded_jobs(tmp_path: Path) -> None:
+def test_docker_ci_builds_only_cpu_images_on_hosted_runners() -> None:
     job = _docker_job()
-    matrix = _selected_images(tmp_path, "true")
+    matrix = job["strategy"]["matrix"]["include"]
 
-    assert job["needs"] == "prepare-matrix"
-    assert job["strategy"]["matrix"] == "${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}"
-    assert job["timeout-minutes"] == "${{ matrix.timeout_minutes }}"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 90
     assert {(entry["target"], entry["repository"], entry["tag_suffix"]) for entry in matrix} == {
-        ("cli-gpu", "boxmot/boxmot", ""),
         ("cli-cpu", "boxmot/boxmot", "-cpu"),
         ("service-cpu", "boxmot/boxmot-service", ""),
-        ("service-gpu", "boxmot/boxmot-service", "-gpu"),
     }
-    assert all(isinstance(entry["timeout_minutes"], int) and entry["timeout_minutes"] > 0 for entry in matrix)
-    gpu_service = next(entry for entry in matrix if entry["target"] == "service-gpu")
-    assert gpu_service["runner"] == "gpu-latest"
-    assert gpu_service["timeout_minutes"] >= 120
+
+
+def test_gpu_images_are_available_only_as_local_docker_targets() -> None:
+    workflow = DOCKER_WORKFLOW.read_text(encoding="utf-8")
+    for target in ("cli-gpu", "service-gpu"):
+        assert target not in workflow
+        assert _docker_stage(target)
+    assert "BOXMOT_GPU_SERVICE_CI" not in workflow
+    assert "gpu-latest" not in workflow
+    assert "--gpus" not in workflow
 
 
 def test_manual_image_rebuild_is_explicit_and_safe_by_default() -> None:
@@ -108,7 +78,7 @@ def test_every_docker_image_checks_the_exact_v24_surface() -> None:
     assert "--workdir /tmp" in script
 
 
-@pytest.mark.parametrize("target", ("cli-cpu", "cli-gpu", "service-cpu", "service-gpu"))
+@pytest.mark.parametrize("target", ("cli-cpu", "service-cpu"))
 def test_docker_release_smoke_preserves_each_images_import_context(tmp_path: Path, target: str) -> None:
     """Execute the workflow's Python flags against a source-only package fixture."""
     step = next(
@@ -272,23 +242,12 @@ def test_release_cli_help_checks_every_command_and_reports_failures(monkeypatch:
         release_contract.check_cli_help()
 
 
-def test_service_gpu_smoke_still_executes_cuda_reid_request() -> None:
-    job = _docker_job()
-    step = next(step for step in job["steps"] if step.get("name") == "Smoke test GPU service image")
-    script = step["run"]
-
-    assert "--gpus all" in script
-    assert "torch.cuda.is_available()" in script
-    assert "/v1/streams/smoke-camera/sessions/smoke-run/frames" in script
-    assert "active CUDA context after ReID inference" in script
-
-
 def test_cli_images_smoke_prebuilt_native_tracker_without_toolchain() -> None:
     job = _docker_job()
     step = next(step for step in job["steps"] if step.get("name") == "Smoke test prebuilt native tracker")
     script = step["run"]
 
-    assert step["if"] == "matrix.target == 'cli-cpu' || matrix.target == 'cli-gpu'"
+    assert step["if"] == "matrix.target == 'cli-cpu'"
     assert "python -I -" in script
     assert 'shutil.which("cmake") is None' in script
     assert 'shutil.which("g++") is None' in script

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -133,8 +133,10 @@ def test_docker_release_smoke_preserves_each_images_import_context(tmp_path: Pat
         "import sys\nimport boxmot\n"
         + (
             "assert sys.flags.isolated == 0\nassert boxmot.source_only_service is True\n"
+            "assert '--check-trackers' not in sys.argv\nassert '--check-cli-help' not in sys.argv\n"
             if target.startswith("service-")
             else "assert sys.flags.isolated == 1\nassert not hasattr(boxmot, 'source_only_service')\n"
+            "assert '--check-trackers' in sys.argv\nassert '--check-cli-help' in sys.argv\n"
         ),
         encoding="utf-8",
     )
@@ -176,7 +178,7 @@ def test_wheel_smoke_uses_shared_checks_without_importing_the_checkout() -> None
     assert smoke["working-directory"] == "${{ runner.temp }}"
     assert smoke["env"]["RELEASE_VERSION"] == "${{ needs.build.outputs.version }}"
     assert 'python -I "$GITHUB_WORKSPACE/source/tests/ci/release_contract.py"' in smoke["run"]
-    assert '--expected-version "$RELEASE_VERSION" --check-cli-help' in smoke["run"]
+    assert '--expected-version "$RELEASE_VERSION" --check-cli-help --check-trackers' in smoke["run"]
     assert "expected_public_api" not in smoke["run"]
     assert "expected_cli_commands" not in smoke["run"]
 

--- a/tests/unit/test_docker_workflow_v24.py
+++ b/tests/unit/test_docker_workflow_v24.py
@@ -300,7 +300,7 @@ def test_cli_images_smoke_prebuilt_native_tracker_without_toolchain() -> None:
 
 
 def test_cpu_service_uses_its_locked_cpu_torch_group() -> None:
-    service_builder = _docker_stage("service-cpu-builder")
+    service_builder = _docker_stage("service-cpu-dependencies")
     pyproject = PYPROJECT.read_text(encoding="utf-8")
 
     assert "--only-group service-runtime" in service_builder
@@ -318,14 +318,13 @@ def test_cpu_service_uses_its_locked_cpu_torch_group() -> None:
 def test_cli_images_package_native_libraries_without_runtime_build_tools() -> None:
     native_builder = _docker_stage("native-cli-builder")
     cli_runtime = _docker_stage("cli-runtime")
-    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    wheel_builder = _docker_stage("cli-wheel-builder")
 
     for dependency in ("cmake", "libeigen3-dev", "libopencv-dev", "ninja-build"):
         assert dependency in native_builder
         assert dependency not in cli_runtime
     assert "-DBOXMOT_INSTALL_NATIVE=ON" in native_builder
-    assert dockerfile.count("COPY --from=native-cli-builder") == 2
-    assert dockerfile.count("ctypes.CDLL") == 2
+    assert "COPY --from=native-cli-builder" in wheel_builder
     for runtime_library in (
         "libopencv-calib3d406",
         "libopencv-core406",

--- a/tests/unit/test_release_tracker_smoke.py
+++ b/tests/unit/test_release_tracker_smoke.py
@@ -1,0 +1,99 @@
+"""Verify that release smoke catches unusable public tracker installations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import boxmot
+from boxmot.trackers import TrackerSpec
+from boxmot.trackers import config as tracker_config
+from boxmot.trackers.common.appearance.live import LiveReIDMixin
+from tests.ci import release_contract
+
+
+@pytest.fixture
+def forbid_reid_loading(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail before an omitted synthetic embedding can construct a model."""
+
+    def unexpected_model_loading(self: LiveReIDMixin) -> None:
+        raise AssertionError("Release smoke must supply embeddings without constructing a ReID model")
+
+    monkeypatch.setattr(LiveReIDMixin, "_get_live_reid_model", unexpected_model_loading)
+    monkeypatch.setattr(LiveReIDMixin, "_get_live_reid_encoder", unexpected_model_loading)
+
+
+@pytest.mark.parametrize("failure", ("missing-export", "missing-module", "missing-class"))
+def test_tracker_smoke_resolves_lazy_exports_despite_unchanged_public_names(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    public_name = "BoostTrack"
+    module_name, _ = boxmot._EXPORTS[public_name]
+    monkeypatch.delitem(boxmot.__dict__, public_name, raising=False)
+    if failure == "missing-export":
+        monkeypatch.delitem(boxmot._EXPORTS, public_name)
+    elif failure == "missing-module":
+        monkeypatch.setitem(boxmot._EXPORTS, public_name, ("boxmot.missing_release_tracker", public_name))
+    else:
+        monkeypatch.setitem(boxmot._EXPORTS, public_name, (module_name, "MissingReleaseTracker"))
+
+    assert boxmot.__all__ == release_contract.EXPECTED_PUBLIC_API
+    expected_error = ModuleNotFoundError if failure == "missing-module" else AttributeError
+    with pytest.raises(expected_error):
+        release_contract.check_tracker_imports()
+
+
+def test_tracker_smoke_rejects_a_public_name_resolving_to_another_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(boxmot, "BoostTrack", boxmot.ByteTrack)
+
+    with pytest.raises(AssertionError, match=r"boxmot.BoostTrack resolves to"):
+        release_contract.check_tracker_imports()
+
+
+def test_tracker_smoke_propagates_factory_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken_factory(spec: TrackerSpec) -> None:
+        raise RuntimeError(f"Cannot construct packaged tracker {spec.name}")
+
+    monkeypatch.setattr(boxmot, "create_tracker", broken_factory)
+
+    with pytest.raises(RuntimeError, match="Cannot construct packaged tracker boosttrack"):
+        release_contract.check_tracker_api()
+
+
+def test_tracker_smoke_requires_packaged_tracker_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(tracker_config, "TRACKER_CONFIGS_DIR", tmp_path)
+
+    with pytest.raises(FileNotFoundError, match=r"Tracker config not found: .*boosttrack.yaml"):
+        release_contract.check_tracker_api()
+
+
+@pytest.mark.usefixtures("forbid_reid_loading")
+@pytest.mark.parametrize(("name", "public_name"), release_contract.EXPECTED_TRACKERS)
+@pytest.mark.parametrize("geometry", ("aabb", "obb"))
+def test_tracker_smoke_runs_real_default_trackers_without_models(name: str, public_name: str, geometry: str) -> None:
+    release_contract.check_tracker_tracking(name, getattr(boxmot, public_name), geometry)
+
+
+def test_tracker_api_smoke_covers_every_geometry_and_runs_the_packed_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, type, str]] = []
+
+    def record_tracking(name: str, tracker_class: type, geometry: str) -> None:
+        calls.append((name, tracker_class, geometry))
+
+    monkeypatch.setattr(release_contract, "check_tracker_tracking", record_tracking)
+
+    # Keep the direct ByteTrack NumPy smoke real while checking its dispatcher.
+    release_contract.check_tracker_api()
+
+    assert calls == [
+        (name, getattr(boxmot, public_name), geometry)
+        for name, public_name in release_contract.EXPECTED_TRACKERS
+        for geometry in ("aabb", "obb")
+    ]


### PR DESCRIPTION
Release smoke now resolves every public tracker export and constructs all ten Python trackers from their packaged defaults. It exercises all twenty AABB/OBB combinations, initial empty input, stable IDs, detection associations, masks, class IDs, and output layouts on CPU with supplied enrichments. A direct ByteTrack call covers packed NumPy input, and every public CLI command runs through installed help.

Docker CI now builds and publishes only `cli-cpu` and `service-cpu`, including manual runs and reusable release gates. GPU targets remain available in the Dockerfile for end users to build locally; the GPU runner switch and GPU image smoke jobs are removed.

System packages, native compilation, Python dependencies, and application installation have separate cache boundaries. A small stage validates the canonical project/lock versions and normalizes only BoxMOT's own version in temporary dependency metadata. Dependency constraints, sources, markers, and artifact hashes remain intact; version-only releases therefore produce identical dependency inputs. The shared native wheel is built from actual release metadata and installed into each CLI runtime after its dependency-only environment has been copied. Service images also copy dependencies and source separately.

## Testing

- `.venv/bin/python -m pytest tests/unit/test_docker_dependency_manifest.py tests/unit/test_docker_cache_layers.py tests/unit/test_docker_native_runtime.py tests/unit/test_docker_workflow_v24.py tests/unit/test_release_tracker_smoke.py tests/unit/test_publish_workflow.py tests/unit/test_release_source_checkout.py tests/ci/python_api_smoke.py -q` — **114 passed**.
- Metadata tests prove identical output for patch/minor/major changes, preservation of third-party versions/hashes/sources, and rejection of mismatched root versions or input overwrites. All four Docker profiles have identical original/normalized frozen dependency exports; a deterministic fixture also passes offline locked sync. A standalone helper check passed with Python 3.11.
- Stage-graph checks cover metadata-free system/native ancestry, normalized dependency inputs, CPU/CUDA profile selection for local builds, dependency-only runtime layers, actual release metadata for the wheel, and native loading without a runtime toolchain. Workflow tests require exactly two CPU image targets.
- `.venv/bin/ruff check docker/dependency_manifest.py tests/unit/test_docker_dependency_manifest.py tests/unit/test_docker_cache_layers.py tests/unit/test_docker_native_runtime.py tests/unit/test_docker_workflow_v24.py`, `/private/tmp/boxmot-ci-tools/actionlint .github/workflows/docker.yml .github/workflows/wheels.yml .github/workflows/publish.yml`, and `git diff --check` — passed.
- `.venv/bin/python -m mkdocs build --strict --site-dir /private/tmp/boxmot-cpu-only-docker-docs` — passed.
- The installed-wheel tracker check previously passed all twenty tracking cases, direct NumPy tracking, and eleven CLI help commands under isolated Python imports, outside the checkout. The temporary interpreter reused existing dependencies; GitHub's wheel matrix separately installs into clean Python 3.10–3.13 interpreters.
- CPU-only Docker validation is running on GitHub with `push_images=false`. The local Docker daemon is unavailable. No GPU image builds were requested for these changes.

## Cache scope

Layer reuse requires an accessible, retained BuildKit cache. Cold builds still install dependencies. The uv cache mounts remain local to each builder and are not separately exported as download caches. The normalized metadata is never used to build the published BoxMOT wheel.
