### PR TITLE
Guide users to the supported API when importing concrete trackers from boxmot.trackers

### DIFF
--- a/boxmot/trackers/__init__.py
+++ b/boxmot/trackers/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING
 
+from boxmot._tracker_exports import _TRACKER_MANIFEST
+
 if TYPE_CHECKING:
     from boxmot.trackers.protocols import ReIDConfigurableTracker, Tracker, TrackerRequirements
     from boxmot.trackers.specs import GeometryKind, TrackerCapabilities, TrackerFamily, TrackerSpec
@@ -32,14 +34,48 @@ _EXPORTS = {
 }
 
 
+def _tracker_name_hints() -> dict[str, str]:
+    """Guidance for concrete-tracker lookups; never used for resolution.
+
+    Concrete tracker implementations are deliberately absent from this
+    namespace (public API is contracts + factory -- see the v24 package
+    contract test and issue #2353). These hints only fire on *failed*
+    attribute lookups to tell the user where the tracker actually lives, so
+    ``hasattr`` stays False and ``__all__`` is untouched.
+    """
+    hints: dict[str, str] = {}
+    for key, entry in _TRACKER_MANIFEST.items():
+        module_path, _, class_name = entry.class_path.rpartition(".")
+        message = (
+            "concrete tracker implementations are not exported from the "
+            "'boxmot.trackers' namespace (public API is contracts + factory). "
+            f"Use create_tracker(TrackerSpec(name={key!r})), "
+            f"from boxmot import {class_name}, "
+            f"or from {module_path} import {class_name}."
+        )
+        hints[class_name] = message
+        # Also catch the lowercase manifest key (e.g. ``botsort``).
+        hints.setdefault(key, message)
+    return hints
+
+
+_TRACKER_NAME_HINTS = _tracker_name_hints()
+del _tracker_name_hints
+
+
 def __getattr__(name: str):
     try:
         module_name, attribute = _EXPORTS[name]
-    except KeyError as exc:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
-    value = getattr(import_module(module_name), attribute)
-    globals()[name] = value
-    return value
+    except KeyError:
+        pass
+    else:
+        value = getattr(import_module(module_name), attribute)
+        globals()[name] = value
+        return value
+    hint = _TRACKER_NAME_HINTS.get(name)
+    if hint is not None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}: {hint}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:

--- a/tests/unit/trackers/test_tracker_package.py
+++ b/tests/unit/trackers/test_tracker_package.py
@@ -228,3 +228,78 @@ def test_removed_common_tracks_exports_stay_absent() -> None:
     assert not hasattr(common_module, "tracks")
     assert not hasattr(common_module, "BoxTrack")
     assert not hasattr(common_module, "SortBoxTrack")
+
+
+def test_concrete_tracker_lookups_raise_guided_error() -> None:
+    """Regression test for https://github.com/mikel-brostrom/boxmot/issues/2353.
+
+    Concrete tracker implementations are deliberately absent from the
+    ``boxmot.trackers`` namespace (public API is contracts + factory -- see the
+    v24 package contract test), so attribute access must keep failing. The
+    failure should instead tell the user where the tracker actually lives.
+    """
+    trackers_module = importlib.import_module("boxmot.trackers")
+
+    for tracker_name, class_name, module_name in _TRACKER_EXPORTS:
+        assert not hasattr(trackers_module, class_name)
+        with pytest.raises(AttributeError) as excinfo:
+            getattr(trackers_module, class_name)
+        message = str(excinfo.value)
+        assert f"create_tracker(TrackerSpec(name={tracker_name!r}))" in message
+        assert f"from boxmot import {class_name}" in message
+        assert f"from {module_name} import {class_name}" in message
+        assert class_name not in trackers_module.__all__
+
+    # The lowercase manifest key is guided too.
+    with pytest.raises(AttributeError, match=r"create_tracker\(TrackerSpec\(name='botsort'\)\)"):
+        getattr(trackers_module, "botsort")
+
+
+def test_trackers_subpackage_public_contract_stays_clean() -> None:
+    """The guided error must not widen the public namespace (v24 contract)."""
+    trackers_module = importlib.import_module("boxmot.trackers")
+
+    assert trackers_module.__all__ == (
+        "GeometryKind",
+        "ReIDConfigurableTracker",
+        "Tracker",
+        "TrackerCapabilities",
+        "TrackerFamily",
+        "TrackerRequirements",
+        "TrackerSpec",
+        "create_tracker",
+    )
+    for implementation_name in ("ByteTrack", "BotSort", "StrongSort", "Sam2Mot"):
+        assert not hasattr(trackers_module, implementation_name)
+
+
+def test_guided_error_path_imports_no_implementation() -> None:
+    """Raising the guided error must not import any implementation module."""
+    repo_root = Path(__file__).resolve().parents[3]
+    script = """
+import sys
+
+import boxmot.trackers
+
+assert not any(
+    name.startswith(("boxmot.trackers.box.", "boxmot.trackers.multimodal."))
+    for name in sys.modules
+)
+
+try:
+    boxmot.trackers.BotSort
+except AttributeError as exc:
+    assert "create_tracker(TrackerSpec(name='botsort'))" in str(exc), str(exc)
+else:
+    raise AssertionError("expected AttributeError")
+
+assert "boxmot.trackers.box.botsort.tracker" not in sys.modules
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
Relates to #2353.

**Pivot:** the original revision of this PR re-exported the 10 concrete tracker
classes from `boxmot.trackers`, but that conflicts with the deliberate v24
public-package contract (`tests/unit/trackers/test_v24_tracker_contract.py`
asserts `__all__` holds only contracts + factory and that implementations are
not attributes of the package). This revision keeps that contract intact
instead of fighting it.

**What it does:** `boxmot/trackers/__init__.py`'s `__getattr__` now recognizes
concrete tracker names (from the canonical `_TRACKER_MANIFEST`, covering both
class names like `BotSort` and lowercase keys like `botsort`) and raises an
`AttributeError` that tells the user exactly where the tracker lives:

```
module 'boxmot.trackers' has no attribute 'BotSort': concrete tracker
implementations are not exported from the 'boxmot.trackers' namespace
(public API is contracts + factory). Use
create_tracker(TrackerSpec(name='botsort')), from boxmot import BotSort, or
from boxmot.trackers.box.botsort.tracker import BotSort.
```

`hasattr` stays `False`, `__all__` is untouched, and the error path imports no
implementation modules (verified by test). Users hitting the confusing bare
`ImportError` from #2353 now get pointed at the three working alternatives.

**Tests** (added to `tests/unit/trackers/test_tracker_package.py`):
1. `test_concrete_tracker_lookups_raise_guided_error` -- all 10 tracker names
   raise the guided `AttributeError` (message contents asserted), `hasattr`
   stays `False`, `__all__` unchanged.
2. `test_trackers_subpackage_public_contract_stays_clean` -- mirrors the v24
   contract assertions to guard this change.
3. `test_guided_error_path_imports_no_implementation` -- fresh-process check
   that the error path loads no implementation modules.
